### PR TITLE
PR for handling scalability issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ export CNI_BIN_HOSTPATH = $(shell kubectl get po -A --selector app=multus -o jso
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+# VERSION ?= 0.0.1
+VERSION ?= 1.0.1-alpha
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -44,7 +45,7 @@ IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/multi-nic-cni-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)/bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE)/controller:latest
+IMG ?= $(IMAGE_TAG_BASE)/controller:v$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: net/multi-nic-cni/controller
-  newTag: latest
+  newName: res-cpe-team-docker-local.artifactory.swg-devops.com/multi-nic-cni-operator/controller
+  newTag: v1.0.1-alpha
+patches:
+- path: patches/image_pull_secret.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,9 +50,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 500Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 500Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -11,4 +11,6 @@ kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
   newName: res-cpe-team-docker-local.artifactory.swg-devops.com/net/multi-nic-cni-daemon
-  newTag: v1.0.0-alpha
+  newTag: v1.0.1-alpha
+patches:
+- path: patches/image_pull_secret.yaml

--- a/config/samples/net.cogadvisor.io_v1_config.template
+++ b/config/samples/net.cogadvisor.io_v1_config.template
@@ -7,8 +7,8 @@ spec:
   ipamType: multi-nic-ipam
   joinPath: /join
   getInterfacePath: /interface
-  addRoutePath: /addroute
-  deleteRoutePath: /deleteroute
+  addRoutePath: /addl3
+  deleteRoutePath: /deletel3
   daemon:
     image: multi-nic-cni-daemon
     imagePullPolicy: Always
@@ -17,6 +17,8 @@ spec:
     env:
     - name: DAEMON_PORT
       value: "11000"
+    - name: RT_TABLE_PATH
+      value: /opt/rt_tables
     mounts:
     - name: cnibin
       podpath: /host/opt/cni/bin
@@ -24,6 +26,9 @@ spec:
     - name: device-plugin
       podpath: /var/lib/kubelet/device-plugins
       hostpath: /var/lib/kubelet/device-plugins
+    - name: rt-tables
+      podpath: /opt/rt_tables
+      hostpath: /etc/iproute2/rt_tables
     port: 11000
     resources:
       requests:

--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/foundation-model-stack/multi-nic-cni/compute"
 	"github.com/foundation-model-stack/multi-nic-cni/plugin"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -130,9 +129,6 @@ func (h *CIDRHandler) CleanPreviousCIDR(config *rest.Config, defHandler *plugin.
 			defName := ippool.Spec.NetAttachDefName
 			_, err := h.GetCIDR(defName)
 			if err != nil {
-				// delete corrsponding routes
-				daemonMap, _ := h.RouteHandler.GetDaemonHostMap()
-				h.DeleteRouteFromIPPool(daemonMap, ippool.Spec)
 				// corresponding CIDR does not exist, delete CIDR
 				h.DeleteIPPool(defName, ippool.Spec.PodCIDR)
 			}
@@ -165,51 +161,10 @@ func (h *CIDRHandler) DeleteCIDR(cidr netcogadvisoriov1.CIDR) error {
 	return fmt.Errorf("%s", errorMsg)
 }
 
-// DeleteRouteFromIPPool deletes routes according to IPPool by calling daemon process via DaemonConnector
-func (h *CIDRHandler) DeleteRouteFromIPPool(daemonMap map[string]corev1.Pod, ippool netcogadvisoriov1.IPPoolSpec) {
-	srcIface := ippool.InterfaceName
-	srcHostInterface, err := h.HostInterfaceHandler.GetHostInterface(ippool.HostName)
-	if err == nil {
-		net := ippool.PodCIDR
-		ifaceNetAddress := ""
-		for _, iface := range srcHostInterface.Spec.Interfaces {
-			if iface.InterfaceName == srcIface {
-				ifaceNetAddress = iface.NetAddress
-				break
-			}
-		}
-		if ifaceNetAddress != "" {
-			hifList, _ := h.HostInterfaceHandler.ListHostInterface()
-			for neighHostName, neighHostInterface := range hifList {
-				for _, iface := range neighHostInterface.Spec.Interfaces {
-					if iface.NetAddress == ifaceNetAddress {
-						ifaceName := iface.InterfaceName
-						via := iface.HostIP
-						neighPod := daemonMap[neighHostName]
-						res, err := h.RouteHandler.DeleteRoute(neighPod, net, via, ifaceName)
-						if err == nil && res.Success {
-							h.Log.Info(fmt.Sprintf("Delete routes %s from %s", net, neighHostName))
-						} else {
-							h.Log.Info(fmt.Sprintf("Cannot delete route %s from %s: %v, %v", net, neighHostName, res, err))
-						}
-						break
-					}
-				}
-			}
-		} else {
-			h.Log.Info(fmt.Sprintf("Cannot get source network address: %s", net))
-		}
-	} else {
-		h.Log.Info(fmt.Sprintf("Cannot get source hif: %v", err))
-	}
-}
-
 // deleteRoutesFromCIDR deletes routes from CIDR
 func (h *CIDRHandler) deleteRoutesFromCIDR(cidrInfo netcogadvisoriov1.CIDRSpec) {
 	if h.IsL3Mode(cidrInfo.Config) {
-		hostInterfaceInfoMap := h.GetHostInterfaceIndexMap(cidrInfo.CIDRs)
-		failMap := h.RouteHandler.DeleteRoutes(cidrInfo.CIDRs, hostInterfaceInfoMap)
-		h.Log.Info(fmt.Sprintf("Delete CIDR %s; delete fail map: %v", cidrInfo.Config.Name, failMap))
+		h.RouteHandler.DeleteRoutes(cidrInfo)
 	}
 }
 
@@ -414,7 +369,7 @@ func (h *CIDRHandler) UpdateCIDR(cidrSpec netcogadvisoriov1.CIDRSpec, defNamespa
 		// update IPPools
 		for _, entry := range newEntries {
 			for _, host := range entry.Hosts {
-				err = h.IPPoolHandler.UpdateIPPool(def.Name, host.PodCIDR, entry.VlanCIDR, host.HostName, host.InterfaceName, excludes)
+				err = h.IPPoolHandler.UpdateIPPool(cidrSpec.Config.Name, host.PodCIDR, entry.VlanCIDR, host.HostName, host.InterfaceName, excludes)
 				if err != nil {
 					h.Log.Info(fmt.Sprintf("Cannot update IPPools for host %s: error=%v", host.HostName, err))
 				}
@@ -422,10 +377,10 @@ func (h *CIDRHandler) UpdateCIDR(cidrSpec netcogadvisoriov1.CIDRSpec, defNamespa
 		}
 
 		// add routes
-
 		if h.IsL3Mode(def) {
 			hostInterfaceInfoMap := h.GetHostInterfaceIndexMap(newEntries)
-			routeChange, _ = h.RouteHandler.AddRoutes(newEntries, hostInterfaceInfoMap, false)
+			h.RouteHandler.DeleteRoutes(cidrSpec)
+			routeChange = h.RouteHandler.AddRoutes(cidrSpec, newEntries, hostInterfaceInfoMap)
 		}
 
 		h.Mutex.Unlock()
@@ -435,15 +390,14 @@ func (h *CIDRHandler) UpdateCIDR(cidrSpec netcogadvisoriov1.CIDRSpec, defNamespa
 	// try re-adding routes
 	if h.IsL3Mode(def) {
 		hostInterfaceInfoMap := h.GetHostInterfaceIndexMap(entries)
-		routeChange, _ = h.RouteHandler.AddRoutes(entries, hostInterfaceInfoMap, true)
+		routeChange = h.RouteHandler.AddRoutes(cidrSpec, entries, hostInterfaceInfoMap)
 	}
 	h.Mutex.Unlock()
 	return routeChange, nil
 }
 
-// cleanPendingIPPools clean ippools adn routes in case that cidr is updated with new subnet entry
+// cleanPendingIPPools clean ippools in case that cidr is updated with new subnet entry
 func (h *CIDRHandler) cleanPendingIPPools(defName string, oldCIDR *netcogadvisoriov1.CIDR, newCIDR *netcogadvisoriov1.CIDR) {
-	daemonMap, _ := h.RouteHandler.GetDaemonHostMap()
 	newPoolMap := make(map[string]bool)
 
 	for _, entry := range newCIDR.Spec.CIDRs {
@@ -458,10 +412,6 @@ func (h *CIDRHandler) cleanPendingIPPools(defName string, oldCIDR *netcogadvisor
 			if _, exist := newPoolMap[ippoolName]; !exist {
 				ippool, err := h.IPPoolHandler.GetIPPool(ippoolName)
 				if err == nil {
-					// found
-					if h.IsL3Mode(oldCIDR.Spec.Config) {
-						h.DeleteRouteFromIPPool(daemonMap, ippool.Spec)
-					}
 					// corresponding CIDR does not exist, delete CIDR
 					h.DeleteIPPool(defName, ippool.Spec.PodCIDR)
 				}

--- a/controllers/hostinterface_handler.go
+++ b/controllers/hostinterface_handler.go
@@ -43,7 +43,7 @@ func (h *HostInterfaceHandler) CreateHostInterface(hostName string, interfaces [
 }
 
 // UpdateHostInterface updates HostInterface
-func (h *HostInterfaceHandler) UpdateHostInterface(oldObj netcogadvisoriov1.HostInterface, interfaces []netcogadvisoriov1.InterfaceInfoType) error {
+func (h *HostInterfaceHandler) UpdateHostInterface(oldObj netcogadvisoriov1.HostInterface, interfaces []netcogadvisoriov1.InterfaceInfoType) (*netcogadvisoriov1.HostInterface, error) {
 	updateHif := &netcogadvisoriov1.HostInterface{
 		ObjectMeta: oldObj.ObjectMeta,
 		Spec: netcogadvisoriov1.HostInterfaceSpec{
@@ -51,7 +51,7 @@ func (h *HostInterfaceHandler) UpdateHostInterface(oldObj netcogadvisoriov1.Host
 			Interfaces: interfaces,
 		},
 	}
-	return h.Client.Update(context.TODO(), updateHif)
+	return updateHif, h.Client.Update(context.TODO(), updateHif)
 }
 
 // GetHostInterface gets HostInterface from hostname

--- a/controllers/synchronizer.go
+++ b/controllers/synchronizer.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func RunPeriodicUpdate(ticker *time.Ticker, cidrHandler *CIDRHandler, hostInterfaceReconciler *HostInterfaceReconciler, logger logr.Logger, quit chan struct{}) {
+	go func() {
+		for {
+			select {
+			case <-quit:
+				return
+			case <-ticker.C:
+				// update interface
+				logger.Info(fmt.Sprintf("synchronizing state... %d HostInterfaces, %d CIDRs", len(HostInterfaceCache), len(CIDRCache)))
+				for _, instance := range HostInterfaceCache {
+					hostInterfaceReconciler.UpdateInterfaces(instance)
+				}
+				for _, instanceSpec := range CIDRCache {
+					cidrHandler.SyncCIDRRoute(instanceSpec, false)
+				}
+			}
+		}
+	}()
+}

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,7 +6,7 @@ export DAEMON_REGISTRY = res-cpe-team-docker-local.artifactory.swg-devops.com
 
 # DAEMON_IMG defines the image:tag used for daemon
 DAEMON_TAG_BASE = net/multi-nic-cni
-DAEMON_VERSION ?= v1.0.0-alpha
+DAEMON_VERSION ?= v1.0.1-alpha
 DAEMON_IMG ?= $(DAEMON_REGISTRY)/$(DAEMON_TAG_BASE)-daemon:$(DAEMON_VERSION)
 
 

--- a/daemon/src/Makefile
+++ b/daemon/src/Makefile
@@ -10,7 +10,7 @@ export PATH := $(PATH):$(ENVTEST_ASSETS_DIR)
 test: SHELL := /bin/bash
 test:  ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
@@ -21,6 +21,6 @@ build: test
 test-verbose: SHELL := /bin/bash
 test-verbose:  ## Run tests with verbose option
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -coverprofile cover.out

--- a/daemon/src/allocator/allocator_test.go
+++ b/daemon/src/allocator/allocator_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+ package allocator
+
+ import (
+	 . "github.com/onsi/ginkgo"
+	 . "github.com/onsi/gomega"
+	 "testing"
+
+	 "github.com/foundation-model-stack/multi-nic-cni/daemon/backend"
+ )
+
+ func TestAllocator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Allocator Test Suite")
+}
+
+func genAllocation(indexes []int) []backend.Allocation {
+	var allocations []backend.Allocation
+	for _, index := range indexes {
+		allocations = append(allocations, backend.Allocation{Index: index})
+	}
+	return allocations
+}
+
+ var _ = Describe("Test Allocator", func() {
+	initIndexes := []int{1,2,3,8,13,18}
+	allocations := genAllocation(initIndexes)
+
+	It("find simple next available index" , func() {
+		indexes := []int{1,2,3,8,13,18}
+		nextIndex := FindAvailableIndex(indexes,0)
+		Expect(nextIndex).To(Equal(4))
+	})
+
+	It("find next available index with exclude range over consecutive order" , func() {
+		excludes := []ExcludeRange {
+			ExcludeRange {
+				MinIndex: 4,
+				MaxIndex: 6,
+			},
+		}
+		indexes := GenerateAllocateIndexes(allocations,20,excludes)
+		Expect(indexes).To(Equal([]int{1,2,3,4,5,6,8,13,18}))
+		nextIndex := FindAvailableIndex(indexes,0)
+		Expect(nextIndex).To(Equal(7))
+	})
+	It("find next available index with exclude range over non-consecutive order" , func() {
+		excludes := []ExcludeRange {
+			ExcludeRange {
+				MinIndex: 4,
+				MaxIndex: 7,
+			},
+		}
+	
+		indexes := GenerateAllocateIndexes(allocations,20,excludes)
+		Expect(indexes).To(Equal([]int{1,2,3,4,5,6,7,8,13,18}))
+		nextIndex := FindAvailableIndex(indexes,0)
+		Expect(nextIndex).To(Equal(9))
+	})
+
+	It("find next available index with exclude range over non-consecutive and then consecutive order" , func() {
+		excludes := []ExcludeRange {
+			ExcludeRange {
+				MinIndex: 4,
+				MaxIndex: 7,
+			},
+			ExcludeRange {
+				MinIndex: 9,
+				MaxIndex: 12,
+			},
+		}
+	
+		indexes := GenerateAllocateIndexes(allocations,20,excludes)
+		Expect(indexes).To(Equal([]int{1,2,3,4,5,6,7,8,9,10,11,12,13,18}))
+		nextIndex := FindAvailableIndex(indexes,0)
+		Expect(nextIndex).To(Equal(14))
+	})
+})

--- a/daemon/src/main.go
+++ b/daemon/src/main.go
@@ -42,6 +42,9 @@ const (
 	ADD_ROUTE_PATH    = "/addroute"
 	DELETE_ROUTE_PATH = "/deleteroute"
 
+	ADD_L3CONFIG_PATH = "/addl3"
+	DELETE_L3CONFIG_PATH = "/deletel3"
+
 	ALLOCATE_PATH   = "/allocate"
 	DEALLOCATE_PATH = "/deallocate"
 
@@ -57,6 +60,8 @@ func handleRequests() *mux.Router {
 	router.HandleFunc(INTERFACE_PATH, GetInterface)
 	router.HandleFunc(ADD_ROUTE_PATH, AddRoute).Methods("POST")
 	router.HandleFunc(DELETE_ROUTE_PATH, DeleteRoute).Methods("POST")
+	router.HandleFunc(ADD_L3CONFIG_PATH, ApplyL3Config).Methods("POST")
+	router.HandleFunc(DELETE_L3CONFIG_PATH, DeleteL3Config).Methods("POST")
 	router.HandleFunc(NIC_SELECT_PATH, SelectNic).Methods("POST")
 	router.HandleFunc(ALLOCATE_PATH, Allocate).Methods("POST")
 	router.HandleFunc(DEALLOCATE_PATH, Deallocate).Methods("POST")
@@ -139,6 +144,16 @@ func GetInterface(w http.ResponseWriter, r *http.Request) {
 
 func AddRoute(w http.ResponseWriter, r *http.Request) {
 	response := dr.AddRoute(r)
+	json.NewEncoder(w).Encode(response)
+}
+
+func ApplyL3Config(w http.ResponseWriter, r *http.Request) {
+	response := dr.ApplyL3Config(r)
+	json.NewEncoder(w).Encode(response)
+}
+
+func DeleteL3Config(w http.ResponseWriter, r *http.Request) {
+	response := dr.DeleteL3Config(r)
 	json.NewEncoder(w).Encode(response)
 }
 
@@ -232,6 +247,7 @@ func main() {
 			DAEMON_PORT = setDaemonPortInt
 		}
 	}
+	dr.SetRTTablePath()
 	
 	da.CleanHangingAllocation(hostName)
 	router := handleRequests()

--- a/daemon/src/router/router.go
+++ b/daemon/src/router/router.go
@@ -17,6 +17,13 @@ import (
 )
 
 // For L3 Configuration
+type L3ConfigRequest struct {
+	Name 	string 		`json:"name"`
+	Subnet  string      `json:"subnet"`
+	Routes	[]HostRoute `json:"routes"`
+	Force   bool        `json:"force"`
+}
+
 type HostRoute struct {
 	Subnet        string `json:"net"`
 	NextHop       string `json:"via"`
@@ -25,6 +32,65 @@ type HostRoute struct {
 type RouteUpdateResponse struct {
 	Success bool   `json:"success"`
 	Message string `json:"msg"`
+}
+
+func ApplyL3Config(r *http.Request) RouteUpdateResponse {
+	res_msg := ""
+	success := true
+	_, tableID, devRoutesMap, err := getRoutesFromRequest(r, true)
+	if err == nil {
+		for dev, routes := range devRoutesMap {
+			for _, route := range routes {
+				exists, _ := isRouteExist(route, dev) 
+				log.Printf("Add route %s; (%v)", route.String(), exists)
+				if !exists {
+					err = netlink.RouteAdd(&route)
+					if err != nil {
+						res_msg += fmt.Sprintf("AddRouteError %v;", err)
+						success = false
+					} else {
+						res_msg += fmt.Sprintf("Add route %s;", route.String())
+						success = success && true
+					}
+				} else {
+					res_msg += "Route exists"
+					success = false
+				}
+			}
+		}
+	} else {
+		res_msg += fmt.Sprintf("AddRoutesError %v;", err)
+		success = false
+	}
+	log.Printf("Apply L3 config %d; (%v)", tableID, success)
+	response := RouteUpdateResponse{Success: success, Message: res_msg}
+	return response
+}
+
+
+func DeleteL3Config(r *http.Request) RouteUpdateResponse {
+	tableName, tableID, _, _ := getRoutesFromRequest(r, false)
+	success, res_msg := deleteL3Config(tableName, tableID)
+	response := RouteUpdateResponse{Success: success, Message: res_msg}
+	return response
+}
+
+func deleteL3Config(tableName string, tableID int) (bool, string) {
+	res_msg := ""
+	success := true
+	
+	if tableID == -1 {
+		success = false
+		res_msg += "Failed to get tableID"
+	} else {
+		err := DeleteTable(tableName, tableID)
+		if err != nil {
+			res_msg += err.Error()
+			success = false
+		}
+	}
+	log.Printf("Delete L3 config %s (%v): %s", tableName, success, res_msg)
+	return success, res_msg
 }
 
 func AddRoute(r *http.Request) RouteUpdateResponse {
@@ -85,6 +151,16 @@ func DeleteRoute(r *http.Request) RouteUpdateResponse {
 	return response
 }
 
+func GetRoutes(tableID int) ([]netlink.Route, error) {
+	findTable := &netlink.Route{Table: tableID}
+	routeFilter := netlink.RT_FILTER_TABLE
+
+	family := netlink.FAMILY_V4
+
+	return netlink.RouteListFiltered(family, findTable, routeFilter)
+}
+
+
 func isRouteExist(cmpRoute netlink.Route, dev netlink.Link) (bool, error) {
 	routes, err := netlink.RouteList(dev, netlink.FAMILY_V4)
 	if err != nil {
@@ -98,6 +174,57 @@ func isRouteExist(cmpRoute netlink.Route, dev netlink.Link) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func getRoutesFromRequest(r *http.Request, addIfNotExists bool) (string, int, map[netlink.Link][]netlink.Route, error) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	devRoutesMap := make(map[netlink.Link][]netlink.Route)
+
+	if err != nil {
+		return "", -1, devRoutesMap, err
+	}
+	var req L3ConfigRequest
+	err = json.Unmarshal(reqBody, &req)
+	if err != nil {
+		return "", -1, devRoutesMap, err
+	}
+
+	if req.Force {
+		tableID, err := GetTableID(req.Name, req.Subnet, false)
+		if err == nil {
+			deleteL3Config(req.Name, tableID)
+			log.Printf("force delete %s (%d)", req.Name, tableID)
+		} else {
+			log.Printf("cannot delete %s: %v", req.Name, err)
+		}
+	}
+
+	tableID, err := GetTableID(req.Name, req.Subnet, addIfNotExists)
+	if tableID == -1 || err != nil{
+		return req.Name, tableID, devRoutesMap, err
+	}
+
+	for _, hostRoute := range req.Routes {
+		dev, err := netlink.LinkByName(hostRoute.InterfaceName)
+		if err != nil {
+			continue
+		}
+		if _, ok := devRoutesMap[dev]; !ok {
+			devRoutesMap[dev] = []netlink.Route{}
+		}
+		nextHop := net.ParseIP(hostRoute.NextHop)
+		_, dst, _ := net.ParseCIDR(hostRoute.Subnet)
+		route := netlink.Route{
+			LinkIndex: dev.Attrs().Index,
+			Scope:     netlink.SCOPE_UNIVERSE,
+			Dst:       dst,
+			Gw:        nextHop,
+			Table:     tableID,
+		}
+		devRoutesMap[dev] = append(devRoutesMap[dev], route)
+	}
+
+	return req.Name, tableID, devRoutesMap, err
 }
 
 func getRouteFromRequest(r *http.Request) (netlink.Route, netlink.Link, error) {

--- a/daemon/src/router/router_test.go
+++ b/daemon/src/router/router_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+ package router
+
+ import (
+	 "testing"
+
+	 . "github.com/onsi/ginkgo"
+	 . "github.com/onsi/gomega"
+
+	 "github.com/vishvananda/netlink"
+	 "fmt"
+	 "os"
+ )
+
+ func TestRouter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Router Test Suite")
+}
+
+const (
+	LOCAL_TABLE_ID = 255
+	LOCAL_TABLE_NAME = "local"
+
+	NEW_TABLE_NAME = "newtable"
+
+	POD_RT_PATH = "/opt/rt_tables"
+)
+
+var _ = Describe("Test Path", func() {
+	It("Set RT path", func() {
+		SetRTTablePath()
+		Expect(RT_TABLE_PATH).To(Equal(DEFAULT_RT_TABLE_PATH))
+		os.Setenv("RT_TABLE_PATH", POD_RT_PATH)
+		SetRTTablePath()
+		Expect(RT_TABLE_PATH).To(Equal(POD_RT_PATH))
+		os.Unsetenv("RT_TABLE_PATH")
+		SetRTTablePath()
+		Expect(RT_TABLE_PATH).To(Equal(DEFAULT_RT_TABLE_PATH))	
+	})
+})
+
+var _ = Describe("Test RT Table", func() {
+	It("Get local RT", func() {
+		tableID, err := GetTableID(LOCAL_TABLE_NAME, "192.168.0.0/16", false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableID).To(Equal(LOCAL_TABLE_ID))
+	})
+	It("Add then delete new table.", func() {
+		tableID, err := GetTableID(NEW_TABLE_NAME, "192.168.0.0/16", false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableID).To(Equal(-1))
+		tableID, err = GetTableID(NEW_TABLE_NAME, "192.168.0.0/16", true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableID).Should(BeNumerically(">", 0))
+		fmt.Println("After adding table")
+		routes, err := GetRoutes(tableID)
+		rules, err := netlink.RuleList(netlink.FAMILY_V4)
+		fmt.Printf("Routes: %v\n", routes)
+		fmt.Printf("Rules: %v\n", rules)
+		newTableID, err := GetTableID(NEW_TABLE_NAME, "192.168.0.0/16", false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(newTableID).To(Equal(tableID))
+		err = DeleteTable(NEW_TABLE_NAME, tableID)
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Println("After deleting table")
+		routes, err = GetRoutes(tableID)
+		rules, err = netlink.RuleList(netlink.FAMILY_V4)
+		fmt.Printf("Routes: %v\n", routes)
+		fmt.Printf("Rules: %v\n", rules)
+	})
+})
+
+var _ = BeforeSuite(func() {
+	DeleteTable(NEW_TABLE_NAME, 100)
+	os.Unsetenv("RT_TABLE_PATH")
+})
+
+var _ = AfterSuite(func() {
+	DeleteTable(NEW_TABLE_NAME, 100)
+	os.Unsetenv("RT_TABLE_PATH")
+})

--- a/daemon/src/router/rt_table.go
+++ b/daemon/src/router/rt_table.go
@@ -1,0 +1,186 @@
+package router
+
+import (
+	"os"
+	"io/ioutil"
+	"github.com/vishvananda/netlink"
+	"log"
+	"bufio"
+	"strings"
+	"sort"
+	"strconv"
+	"net"
+	"errors"
+	"fmt"
+)
+
+const (
+	MIX_TABLE_INDEX = 100
+	DEFAULT_RT_TABLE_PATH = "/etc/iproute2/rt_tables"
+)
+
+var RT_TABLE_PATH string = DEFAULT_RT_TABLE_PATH
+
+func SetRTTablePath() {
+	setTablePath, found := os.LookupEnv("RT_TABLE_PATH")
+	if found && setTablePath != "" {
+		RT_TABLE_PATH = setTablePath
+	} else {
+		RT_TABLE_PATH = DEFAULT_RT_TABLE_PATH
+	}
+}
+
+func GetTableID(tableName string, subnet string, addIfNotExists bool) (int, error) {
+	foundID, reservedIDs, err := getTableIDAndReservedIDs(tableName)
+	if err != nil {
+		log.Printf("failed to read %s: %v", RT_TABLE_PATH, err)
+		return foundID, err
+	}
+	if addIfNotExists && foundID == -1 {
+		foundID, err = addTable(tableName, reservedIDs)
+		if err == nil {
+			err = addRule(subnet, foundID)
+		}
+	}
+	return foundID, err
+}
+
+func DeleteTable(tableName string, tableID int) error {
+	err := deleteRoutes(tableID)
+	if err != nil {
+		log.Printf("failed to delete routes in table %d: %v", tableID, err)
+		return err
+	}
+	input, err := ioutil.ReadFile(RT_TABLE_PATH)
+	if err != nil {
+		log.Printf("failed to read %s: %v", RT_TABLE_PATH, err)
+		return err
+	}
+	output := strings.Replace(string(input), getTableLine(tableID, tableName), "", 1)
+	err = ioutil.WriteFile(RT_TABLE_PATH, []byte(output), 0666)
+	if err != nil {
+		log.Printf("failed to update %s: %v", RT_TABLE_PATH, err)
+	}
+	err = deleteRule(tableID)
+	return err
+}
+
+func addRule(subnet string, tableID int) error {
+	_, src, _ := net.ParseCIDR(subnet)
+	rule := netlink.NewRule()
+	rule.Src =  src
+	rule.Table = tableID
+	err := netlink.RuleAdd(rule)
+	log.Printf("add rule %v:%v", rule, err)
+	return err
+}
+
+func getTableID(tableName string) int {
+	file, err := os.Open(RT_TABLE_PATH)
+	if err != nil {
+		return -1
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		splited := strings.Fields(line)
+		if len(splited) > 1 {
+			if splited[1] == tableName {
+				tableID, err := strconv.ParseInt(splited[0], 10, 64)
+				if err != nil {
+					return int(tableID)
+				}
+				return -1
+			} 
+		}
+	}
+	return -1
+}
+
+func getTableIDAndReservedIDs(tableName string) (int, []int, error) {
+	foundID := -1
+	reservedIDs := []int{}
+
+	file, err := os.Open(RT_TABLE_PATH)
+	if err != nil {
+		return foundID, reservedIDs, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		splited := strings.Fields(line)
+		if len(splited) > 1 {
+			tableID, err := strconv.ParseInt(splited[0], 10, 64)
+			if err != nil {
+				continue
+			}
+			if splited[1] == tableName {
+				foundID = int(tableID)
+			} else {
+				if tableID >= MIX_TABLE_INDEX {
+					reservedIDs = append(reservedIDs, int(tableID))
+				}
+			}
+		}
+	}
+	return foundID, reservedIDs, scanner.Err()
+}
+
+func addTable(tableName string, reservedIDs []int) (int, error) {
+	foundID := -1
+	// add table
+	// 1. sort reserved ID
+	sort.Ints(reservedIDs)
+	// 2. find available ID
+	for index, tableID := range reservedIDs {
+		if index + MIX_TABLE_INDEX != tableID {
+			foundID = index + MIX_TABLE_INDEX
+			break
+		}
+	}
+	if foundID != -1 {
+		file, err := os.OpenFile(RT_TABLE_PATH, os.O_APPEND|os.O_WRONLY, 0644)
+		if err == nil {
+			defer file.Close()
+			_, err = file.WriteString(getTableLine(foundID, tableName))
+		}
+		return foundID, err
+	}
+	return foundID, errors.New("No available ID")
+}
+
+func deleteRule(tableID int) error {
+	rule := netlink.NewRule()
+	rule.Table = tableID
+	err := netlink.RuleDel(rule)
+	log.Printf("delete rule %v:%v", rule, err)
+	return err
+}
+
+
+func deleteRoutes(tableID int) error {
+	routes, err := GetRoutes(tableID)
+	if err != nil {
+		return err
+	}
+	deletedNRoute := 0
+	for _, route := range routes {
+		if route.Table == tableID {
+			err = netlink.RouteDel(&route)
+			if err == nil {
+				deletedNRoute += 1
+			} 
+		}
+	}
+	log.Printf("delete %d of %d routes from table %d", deletedNRoute, len(routes), tableID)
+	return nil
+}
+
+
+func getTableLine(tableID int, tableName string) string {
+	return fmt.Sprintf("%d\t%s\n", tableID, tableName)
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,19 +6,23 @@ This terraform will
 - attach created subnets to vsi listed in `worker_names`.
 #### Steps
 1. Install terraform version `>= 0.1.3`
-2. Modify `terraform.tfvars.template`, then copy to `.tfvars` file
+2. Move to provider folder. For example,
+   ```bash
+   cd ibmcloud
+   ```
+3. Modify `terraform.tfvars.template`, then copy to `.tfvars` file
     ```bash
     cp terraform.tfvars.template terraform.tfvars
     ```
-3. Init terraform 
+4. Init terraform 
     ```bash
     terraform init
     ```
-4. Initailly apply with required target (subnets)
+5. Initailly apply with required target (subnets)
     ```bash
     terraform apply -var-file=terraform.tfvars -target="ibm_is_subnet.subnets"
     ```
-5. Apply all targets
+6. Apply all targets
     ```bash
     terraform apply -var-file=terraform.tfvars
     ```

--- a/terraform/ibmcloud/terraform.tfvars.template
+++ b/terraform/ibmcloud/terraform.tfvars.template
@@ -8,7 +8,6 @@ resource_group = <RESOURCE_GROUP>
 region       = "us-south"
 zone         = "us-south-1"
 
-subnet_prefix = "self-managed-ocp"
 subnet_count = "2"
 
 worker_names = [ <WORKER_NAME_LIST> ]


### PR DESCRIPTION
I have mitigated two bottlenecks that might happen due to dynamic change from auto-scaling.
1. one request per one route management (add/delete) overloaded the daemon port.
**solution:** 
    1.  manage CIDR on host as a Table instead of a simple list of routes, so that only one single request is needed when CIDR changes or periodic update
   2. to reduce the request while keep synchronising for the case of node failure, separate synchronising job from the reconcile loop
2. multiple resource get/list (for daemon pods, hostinterfaces, CIDR) for every time that (i) send request to daemon, (ii) update CIDR, etc. causes client-side throttling to API server.
**solution:** 
    cache and update daemonpod, hostinterface, and CIDR at watch point and use cache instead of calling API server. 

> notes: change version to 1.0.1-alpha

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>