### PR TITLE
fix missing rule after rebooting nodes

### DIFF
--- a/controllers/cidr_controller.go
+++ b/controllers/cidr_controller.go
@@ -87,16 +87,12 @@ func (r *CIDRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// sync route from CIDR
 	routeStatus := r.CIDRHandler.SyncCIDRRoute(instance.Spec, true)
 	r.CIDRHandler.MultiNicNetworkHandler.UpdateStatus(*instance, routeStatus)
-	if routeStatus == netcogadvisoriov1.RouteUnknown || routeStatus == netcogadvisoriov1.SomeRouteFailed {
-		// if some routes are not properly updated, retry
-		r.Log.Info(fmt.Sprintf("Requeue CIDR %s, some routes cannot be updated.", cidrName))
-		return ctrl.Result{RequeueAfter: CIDRReconcileTime}, nil
-	} else {
+	if routeStatus == netcogadvisoriov1.AllRouteApplied {
 		//success
 		r.Log.Info(fmt.Sprintf("CIDR %s successfully applied", cidrName))
 		CIDRCache[cidrName] = *instance.Spec.DeepCopy()
-		return ctrl.Result{}, nil
 	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/daemon_watcher.go
+++ b/controllers/daemon_watcher.go
@@ -154,8 +154,9 @@ func (w *DaemonWatcher) ProcessPodQueue() {
 			err := w.createHostInterfaceInfo(*daemon)
 			if err != nil {
 				w.Log.Info(fmt.Sprintf("Fail to create hostinterface %s: %v", daemon.GetName(), err))
-
 			}
+			// sync route is node in the deploying CIDR
+			w.CIDRHandler.SyncCIDRRouteToHost(*daemon)
 		} else {
 			w.Log.Info(fmt.Sprintf("Daemon pod for %s deleted", nodeName))
 			// deleted, delete HostInterface

--- a/controllers/synchronizer.go
+++ b/controllers/synchronizer.go
@@ -22,7 +22,10 @@ func RunPeriodicUpdate(ticker *time.Ticker, cidrHandler *CIDRHandler, hostInterf
 				}
 				for name, instanceSpec := range CIDRCache {
 					routeStatus := cidrHandler.SyncCIDRRoute(instanceSpec, false)
-					cidrHandler.MultiNicNetworkHandler.SyncStatus(name, instanceSpec, routeStatus)
+					err := cidrHandler.MultiNicNetworkHandler.SyncStatus(name, instanceSpec, routeStatus)
+					if err != nil {
+						logger.Info(fmt.Sprintf("failed to update route status of %s: %v", name, err))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes the following issues after rebooting a node.
- Table ID remains while the rule and routes are all deleted. The previous implementation checks if table ID and add rule only if the table is deleted. This PR also checks if the rule exists and add rule if it is missing.
- Instead of waiting for synchronization period (10 minutes),  after node is rebooted, the updated pod will invoke the call SyncCIDRRouteToHost. If it is failed, it will update Unknown status to MultiNICNetwork. MultiNICNetwork reconcile loop will reconcile the resource until route is successfully sync.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>