### PR TITLE
implement build-push ci

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -1,0 +1,83 @@
+name: Build and push controller and its bundle image
+
+on:
+  push:
+    branches:
+      - controller
+      - ci
+
+env:
+  IMAGE_VERSION: '1.0.2'
+
+jobs:
+  build-push-bundle:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-bundle
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: set ARCH and OD
+        run: |
+            echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
+            echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0" >> $GITHUB_ENV
+      - name: download operator-sdk
+        run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
+      - name: move operator-sdk to binary path
+        run: chmod +x operator-sdk_${{ env.OS }}_${{ env.ARCH }} && sudo mv operator-sdk_${{ env.OS }}_${{ env.ARCH }} /usr/local/bin/operator-sdk
+      - name: Tidy
+        run: |
+          go mod tidy
+      - name: Make bundle
+        run: make bundle
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push bundle
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./bundle.Dockerfile
+         
+  build-push-controller:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-controller
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: Tidy
+        run: |
+          go mod tidy
+          make generate fmt vet
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push controller
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./Dockerfile

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -1,0 +1,41 @@
+name: Build and push daemon image
+
+on:
+  push:
+    branches:
+      - daemon
+      - ci
+      
+env:
+  IMAGE_VERSION: '1.0.2'
+
+jobs:
+  build-push-daemon:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-daemon
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: Update CNI
+        run: make update-cni-local
+        working-directory: daemon
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push daemon
+        uses: docker/build-push-action@v2
+        with:
+          context: daemon
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./daemon/Dockerfile

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,37 @@
+name: Perform unittest for controller
+
+on:
+  pull_request:
+    branches:    
+      - '**'        # matches every branch
+      - '!doc'      # excludes master
+  push:
+    branches:    
+      - '**'        # matches every branch
+      - '!doc'      # excludes master
+
+jobs:
+
+  controller-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: set ARCH and OD
+        run: |
+            echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
+            echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0" >> $GITHUB_ENV
+      - name: download operator-sdk
+        run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
+      - name: move operator-sdk to binary path
+        run: chmod +x operator-sdk_${{ env.OS }}_${{ env.ARCH }} && sudo mv operator-sdk_${{ env.OS }}_${{ env.ARCH }} /usr/local/bin/operator-sdk
+      - name: Tidy
+        run: |
+          go mod tidy
+      - name: Make bundle
+        run: make bundle
+      - name: Test Controller
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,15 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# net.cogadvisor.io/multi-nic-cni/bundle:$VERSION and net.cogadvisor.io/multi-nic-cni/catalog:$VERSION.
+# net.cogadvisor.io/multi-nic-cni-bundle:$VERSION and net.cogadvisor.io/multi-nic-cni/catalog:$VERSION.
 IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/multi-nic-cni
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)/bundle:v$(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE)/controller:v$(VERSION)
+IMG ?= $(IMAGE_TAG_BASE)-controller:v$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multi-nic-cni-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.15.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/cni/Makefile
+++ b/cni/Makefile
@@ -38,7 +38,7 @@ tidy:
 test: ginkgo-set plugins-set
 	@cd ./plugins/main/multi-nic && ginkgo
 
-build: ginkgo-set plugins-set tidy
+build: plugins-set tidy
 	@mkdir -p bin
 	@go build -o bin/multi-nic ./plugins/main/multi-nic
 	@go build -o bin/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
@@ -46,7 +46,7 @@ build: ginkgo-set plugins-set tidy
 build-with-test: test build
 
 copy-to-daemon:
-	@rm -r ../daemon/cni
+	@rm -rf ../daemon/cni|| true
 	@mkdir -p ../daemon/cni
 	@cp -r ./pkg ../daemon/cni/pkg
 	@cp -r ./plugins ../daemon/cni/plugins

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -7,7 +7,7 @@ export DAEMON_REGISTRY = ghcr.io/foundation-model-stack
 # DAEMON_IMG defines the image:tag used for daemon
 DAEMON_TAG_BASE = multi-nic-cni
 DAEMON_VERSION ?= v1.0.2
-DAEMON_IMG ?= $(DAEMON_REGISTRY)/$(DAEMON_TAG_BASE)/daemon:$(DAEMON_VERSION)
+DAEMON_IMG ?= $(DAEMON_REGISTRY)/$(DAEMON_TAG_BASE)-daemon:$(DAEMON_VERSION)
 
 
 test-verbose:

--- a/daemon/src/Makefile
+++ b/daemon/src/Makefile
@@ -10,7 +10,7 @@ export PATH := $(PATH):$(ENVTEST_ASSETS_DIR)
 test: SHELL := /bin/bash
 test:  ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
@@ -21,6 +21,6 @@ build: test
 test-verbose: SHELL := /bin/bash
 test-verbose:  ## Run tests with verbose option
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -coverprofile cover.out


### PR DESCRIPTION
This PR mainly implements GitHub Action workflows for automatically building and pushing controller, bundle, and daemon images to the repository. 

There are three workflows:
- `build_push_controller`: build and push controller and its bundle images
- `build_push_daemon`: build CNI, move to daemon local folder, and build and push daemon image
- `unittest`: run test for controller

To avoid unnecessary build and push, 
- The code changes related to controller should be pushed to `controller` branch first to execute `build_push_controller`. 
- Similarly, the code changes related to `daemon` should be pushed to daemon branch to execute `build_push_daemon`.
- As any change related to CI pipelines might affect image build and push, the first two workflows will be also executed on `ci` branch.

The unittest will be executed for all branches except explicitly non-related `doc` branch.

_Detail modifications:_
- to reduce confusion, re-add prefix (multi-nic-cni-) to the image name
- update daemon/CNI Makefile to suppress folder not found error
- update operator-sdk to latest version (v1.23.0)

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>