### PR TITLE
use OPERATOR_NAMESPACE from pod field

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,11 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -24,11 +24,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"os"
 )
 
 const (
-	SERVICE_ACCOUNT_NAME = "multi-nic-cni-operator-controller-manager"
-	OPERATOR_NAMESPACE   = "multi-nic-cni-operator-system"
+	SERVICE_ACCOUNT_NAME       = "multi-nic-cni-operator-controller-manager"
+	DEFAULT_OPERATOR_NAMESPACE = "multi-nic-cni-operator-system"
 
 	// NetworkAttachmentDefinition watching queue size
 	MAX_QSIZE = 100
@@ -36,6 +38,19 @@ const (
 	DAEMON_LABEL_NAME  = "app"
 	DAEMON_LABEL_VALUE = "multi-nicd"
 )
+
+var (
+	OPERATOR_NAMESPACE string = getOperatorNamespace()
+)
+
+func getOperatorNamespace() string {
+	key := "OPERATOR_NAMESPACE"
+	val, found := os.LookupEnv(key)
+	if !found {
+		return DEFAULT_OPERATOR_NAMESPACE
+	}
+	return val
+}
 
 // ConfigReconciler reconciles a Config object
 // - if Config is deleted, delete daemon


### PR DESCRIPTION
This PR fixes the constant OPERATOR_NAMESPACE to allow different namespace when run via [Operator Lifecycle Manager](https://olm.operatorframework.io/).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>