### PR TITLE
Include build/push CI and update bundle target

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -1,0 +1,83 @@
+name: Build and push controller and its bundle image
+
+on:
+  push:
+    branches:
+      - controller
+      - ci
+
+env:
+  IMAGE_VERSION: '1.0.2'
+
+jobs:
+  build-push-bundle:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-bundle
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: set ARCH and OD
+        run: |
+            echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
+            echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0" >> $GITHUB_ENV
+      - name: download operator-sdk
+        run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
+      - name: move operator-sdk to binary path
+        run: chmod +x operator-sdk_${{ env.OS }}_${{ env.ARCH }} && sudo mv operator-sdk_${{ env.OS }}_${{ env.ARCH }} /usr/local/bin/operator-sdk
+      - name: Tidy
+        run: |
+          go mod tidy
+      - name: Make bundle
+        run: make bundle
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push bundle
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./bundle.Dockerfile
+         
+  build-push-controller:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-controller
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: Tidy
+        run: |
+          go mod tidy
+          make generate fmt vet
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push controller
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./Dockerfile

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -1,0 +1,41 @@
+name: Build and push daemon image
+
+on:
+  push:
+    branches:
+      - daemon
+      - ci
+      
+env:
+  IMAGE_VERSION: '1.0.2'
+
+jobs:
+  build-push-daemon:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-daemon
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: Update CNI
+        run: make update-cni-local
+        working-directory: daemon
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push daemon
+        uses: docker/build-push-action@v2
+        with:
+          context: daemon
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./daemon/Dockerfile

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,37 @@
+name: Perform unittest for controller
+
+on:
+  pull_request:
+    branches:    
+      - '**'        # matches every branch
+      - '!doc'      # excludes master
+  push:
+    branches:    
+      - '**'        # matches every branch
+      - '!doc'      # excludes master
+
+jobs:
+
+  controller-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: set ARCH and OD
+        run: |
+            echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
+            echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0" >> $GITHUB_ENV
+      - name: download operator-sdk
+        run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
+      - name: move operator-sdk to binary path
+        run: chmod +x operator-sdk_${{ env.OS }}_${{ env.ARCH }} && sudo mv operator-sdk_${{ env.OS }}_${{ env.ARCH }} /usr/local/bin/operator-sdk
+      - name: Tidy
+        run: |
+          go mod tidy
+      - name: Make bundle
+        run: make bundle
+      - name: Test Controller
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,15 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# net.cogadvisor.io/multi-nic-cni/bundle:$VERSION and net.cogadvisor.io/multi-nic-cni/catalog:$VERSION.
+# net.cogadvisor.io/multi-nic-cni-bundle:$VERSION and net.cogadvisor.io/multi-nic-cni/catalog:$VERSION.
 IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/multi-nic-cni
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)/bundle:v$(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE)/controller:v$(VERSION)
+IMG ?= $(IMAGE_TAG_BASE)-controller:v$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize predeploy ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multi-nic-cni-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.15.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/cni/Makefile
+++ b/cni/Makefile
@@ -38,7 +38,7 @@ tidy:
 test: ginkgo-set plugins-set
 	@cd ./plugins/main/multi-nic && ginkgo
 
-build: ginkgo-set plugins-set tidy
+build: plugins-set tidy
 	@mkdir -p bin
 	@go build -o bin/multi-nic ./plugins/main/multi-nic
 	@go build -o bin/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
@@ -46,7 +46,7 @@ build: ginkgo-set plugins-set tidy
 build-with-test: test build
 
 copy-to-daemon:
-	@rm -r ../daemon/cni
+	@rm -rf ../daemon/cni|| true
 	@mkdir -p ../daemon/cni
 	@cp -r ./pkg ../daemon/cni/pkg
 	@cp -r ./plugins ../daemon/cni/plugins

--- a/config/crd/bases/net.cogadvisor.io_cidrs.yaml
+++ b/config/crd/bases/net.cogadvisor.io_cidrs.yaml
@@ -74,6 +74,8 @@ spec:
                   type: object
                 type: array
               config:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
                 properties:
                   excludeCIDRs:
                     items:
@@ -103,14 +105,9 @@ spec:
                 - subnet
                 - type
                 type: object
-              namespace:
-                description: Foo is an example field of CIDR. Edit cidr_types.go to
-                  remove/update
-                type: string
             required:
             - cidr
             - config
-            - namespace
             type: object
           status:
             description: CIDRStatus defines the observed state of CIDR

--- a/config/crd/bases/net.cogadvisor.io_multinicnetworks.yaml
+++ b/config/crd/bases/net.cogadvisor.io_multinicnetworks.yaml
@@ -110,14 +110,27 @@ spec:
           status:
             description: MultiNicNetworkStatus defines the observed state of MultiNicNetwork
             properties:
-              defs:
-                description: Definitions lists NetworkAttachmentDefinition created
-                  by the MultiNicNetwork
+              computeResults:
                 items:
-                  type: string
+                  properties:
+                    netAddress:
+                      type: string
+                    numOfHosts:
+                      type: integer
+                  required:
+                  - netAddress
+                  - numOfHosts
+                  type: object
                 type: array
+              lastSyncTime:
+                format: date-time
+                type: string
+              routeStatus:
+                type: string
             required:
-            - defs
+            - computeResults
+            - lastSyncTime
+            - routeStatus
             type: object
         type: object
     served: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,7 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: res-cpe-team-docker-local.artifactory.swg-devops.com/multi-nic-cni-operator/controller
-  newTag: v1.0.1-alpha
-patches:
-- path: patches/image_pull_secret.yaml
+  newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
+  newTag: v1.0.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,11 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,6 +2,7 @@
 resources:
 - net.cogadvisor.io_v1_config.yaml
 - net_v1_deviceclass.yaml
+- net_v1_multinicnetwork.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples
 
 configurations:
@@ -10,7 +11,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
-  newName: res-cpe-team-docker-local.artifactory.swg-devops.com/net/multi-nic-cni-daemon
-  newTag: v1.0.1-alpha
-patches:
-- path: patches/image_pull_secret.yaml
+  newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
+  newTag: v1.0.2

--- a/config/samples/net_v1_multinicnetwork.yaml
+++ b/config/samples/net_v1_multinicnetwork.yaml
@@ -1,0 +1,19 @@
+apiVersion: net.cogadvisor.io/v1
+kind: MultiNicNetwork
+metadata:
+  name: sample-network
+spec:
+  subnet: "192.168.0.0/16"
+  ipam: |
+    {
+      "type": "multi-nic-ipam",
+      "hostBlock": 8, 
+      "interfaceBlock": 2,
+      "vlanMode": "l2"
+    }
+  multiNICIPAM: true
+  plugin:
+    cniVersion: "0.3.0"
+    type: ipvlan
+    args: 
+      mode: l2

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -24,11 +24,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"os"
 )
 
 const (
-	SERVICE_ACCOUNT_NAME = "multi-nic-cni-operator-controller-manager"
-	OPERATOR_NAMESPACE   = "multi-nic-cni-operator-system"
+	SERVICE_ACCOUNT_NAME       = "multi-nic-cni-operator-controller-manager"
+	DEFAULT_OPERATOR_NAMESPACE = "multi-nic-cni-operator-system"
 
 	// NetworkAttachmentDefinition watching queue size
 	MAX_QSIZE = 100
@@ -36,6 +38,19 @@ const (
 	DAEMON_LABEL_NAME  = "app"
 	DAEMON_LABEL_VALUE = "multi-nicd"
 )
+
+var (
+	OPERATOR_NAMESPACE string = getOperatorNamespace()
+)
+
+func getOperatorNamespace() string {
+	key := "OPERATOR_NAMESPACE"
+	val, found := os.LookupEnv(key)
+	if !found {
+		return DEFAULT_OPERATOR_NAMESPACE
+	}
+	return val
+}
 
 // ConfigReconciler reconciles a Config object
 // - if Config is deleted, delete daemon

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		defer multinicnetworkReconciler.Client.Delete(context.Background(), multinicnetwork)
 
 		var multiNicNetworkInstance *netcogadvisoriov1.MultiNicNetwork
-		maxTry := 10
+		maxTry := 30
 		count := 0
 		for {
 			multiNicNetworkInstance, err = multinicnetworkReconciler.CIDRHandler.GetNetwork(multinicnetwork.GetName())
@@ -41,6 +41,7 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 			time.Sleep(1)
 			count += 1
 		}
+		fmt.Printf("Try: %d \n", count)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(multiNicNetworkInstance.Status.ComputeResults)).To(Equal(0))
 		multinicnetworkReconciler.HandleMultiNicIPAM(multiNicNetworkInstance)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -7,7 +7,7 @@ export DAEMON_REGISTRY = ghcr.io/foundation-model-stack
 # DAEMON_IMG defines the image:tag used for daemon
 DAEMON_TAG_BASE = multi-nic-cni
 DAEMON_VERSION ?= v1.0.2
-DAEMON_IMG ?= $(DAEMON_REGISTRY)/$(DAEMON_TAG_BASE)/daemon:$(DAEMON_VERSION)
+DAEMON_IMG ?= $(DAEMON_REGISTRY)/$(DAEMON_TAG_BASE)-daemon:$(DAEMON_VERSION)
 
 
 test-verbose:

--- a/daemon/src/Makefile
+++ b/daemon/src/Makefile
@@ -10,7 +10,7 @@ export PATH := $(PATH):$(ENVTEST_ASSETS_DIR)
 test: SHELL := /bin/bash
 test:  ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
@@ -21,6 +21,6 @@ build: test
 test-verbose: SHELL := /bin/bash
 test-verbose:  ## Run tests with verbose option
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -r /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 && mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -coverprofile cover.out


### PR DESCRIPTION
This PR cherry-picks CI implementation and fixes the following issues for bundle preparation.

- **use OPERATOR_NAMESPACE from pod field:** to support deployment on the other namespace from bundle.
```bash
operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:<version> -n <namespace>
```
- **increase max try:** mitigate timely failure on test CI due to deployment latency
- **add predeploy to bundle target:** generate `net.congadvisor.io_v1_config.yaml` from template when run `make bundle`. Otherwise, make bundle will unnoticeably fail due to missing file in kustomization.