### PR TITLE
fix push path in workflows

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
-      - controllers
-      - compute
-      - plugin
+      - controllers/**
+      - compute/**
+      - plugin/**
       - ./main.go
       - ./go.mod
-      - config
+      - config/**
       - ./Dockerfile
       - ./bundle.Dockerfile
       - ./Makefile

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - daemon
-      - cni
+      - daemon/**
+      - cni/**
       
 env:
   IMAGE_VERSION: '1.0.2'


### PR DESCRIPTION
The previous workflows won't be activated when there are changes in folder as expected. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>