### PR TITLE
debug adding namespaces not applied

### DIFF
--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -179,8 +179,7 @@ func (h *CIDRHandler) deleteRoutesFromCIDR(cidrInfo multinicv1.CIDRSpec) {
 func (h *CIDRHandler) GetAllNetAddrs() []string {
 	netAddrSet := []string{}
 	netAddressMap := make(map[string]bool)
-	hifList, _ := h.HostInterfaceHandler.ListHostInterface()
-	for _, hif := range hifList {
+	for _, hif := range HostInterfaceCache {
 		for _, iface := range hif.Spec.Interfaces {
 			netAddr := iface.NetAddress
 			if _, exist := netAddressMap[netAddr]; !exist {

--- a/controllers/multinicnetwork_controller.go
+++ b/controllers/multinicnetwork_controller.go
@@ -117,32 +117,13 @@ func (r *MultiNicNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		return ctrl.Result{}, nil
 	}
-	routeStatus := instance.Status.Status
-	if routeStatus == multinicv1.AllRouteApplied || routeStatus == multinicv1.RouteNoApplied {
-		// status alread applied
-		return ctrl.Result{}, nil
-	} else if routeStatus == multinicv1.RouteUnknown {
-		// some route is failed
-		if cidr, ok := CIDRCache[instance.Name]; ok {
-			routeStatus = r.CIDRHandler.SyncCIDRRoute(cidr, false)
-			err := r.CIDRHandler.MultiNicNetworkHandler.SyncStatus(instance.Name, cidr, routeStatus)
-			if err != nil {
-				r.Log.Info(fmt.Sprintf("failed to update route status of %s: %v", instance.Name, err))
-			}
-			if routeStatus == multinicv1.RouteUnknown {
-				return ctrl.Result{RequeueAfter: ReconcileTime}, nil
-			}
-		}
-	}
 	// setNetAddress if not defined
 	if len(instance.Spec.MasterNetAddrs) == 0 {
 		instance.Spec.MasterNetAddrs = r.CIDRHandler.GetAllNetAddrs()
 	}
 
-	hifList, _ := r.CIDRHandler.HostInterfaceHandler.ListHostInterface()
-
 	// Get main plugin
-	mainPlugin, annotations, err := r.GetMainPluginConf(instance, hifList)
+	mainPlugin, annotations, err := r.GetMainPluginConf(instance)
 
 	if err != nil {
 		r.Log.Info(fmt.Sprintf("Failed to get main config %s: %v", instance.GetName(), err))
@@ -162,13 +143,28 @@ func (r *MultiNicNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{RequeueAfter: ReconcileTime}, nil
 		}
 	}
+
+	routeStatus := instance.Status.Status
+	if routeStatus == multinicv1.RouteUnknown {
+		// some route is failed
+		if cidr, ok := CIDRCache[instance.Name]; ok {
+			routeStatus = r.CIDRHandler.SyncCIDRRoute(cidr, false)
+			err := r.CIDRHandler.MultiNicNetworkHandler.SyncStatus(instance.Name, cidr, routeStatus)
+			if err != nil {
+				r.Log.Info(fmt.Sprintf("failed to update route status of %s: %v", instance.Name, err))
+			}
+			if routeStatus == multinicv1.RouteUnknown {
+				return ctrl.Result{RequeueAfter: ReconcileTime}, nil
+			}
+		}
+	}
 	return ctrl.Result{}, nil
 }
 
-func (r *MultiNicNetworkReconciler) GetMainPluginConf(instance *multinicv1.MultiNicNetwork, hifList map[string]multinicv1.HostInterface) (string, map[string]string, error) {
+func (r *MultiNicNetworkReconciler) GetMainPluginConf(instance *multinicv1.MultiNicNetwork) (string, map[string]string, error) {
 	spec := instance.Spec.MainPlugin
 	if p, exist := r.PluginMap[spec.Type]; exist {
-		return (*p).GetConfig(*instance, hifList)
+		return (*p).GetConfig(*instance, HostInterfaceCache)
 	}
 	return "", map[string]string{}, fmt.Errorf("cannot find plugin %s", spec.Type)
 }

--- a/controllers/multinicnetwork_test.go
+++ b/controllers/multinicnetwork_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Test deploying MultiNicNetwork", func() {
 	multinicnetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, cniArgs)
 
 	It("successfully create/delete network attachment definition", func() {
-		mainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(multinicnetwork, hifList)
+		mainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(multinicnetwork)
 		Expect(err).NotTo(HaveOccurred())
 		err = multinicnetworkReconciler.NetAttachDefHandler.CreateOrUpdate(multinicnetwork, mainPlugin, annotations)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR fixed the bug caused by wrong order handling in multinicnetwork controller.
With PR, the newly-added namespaces in the multinicnetwork CR will be applied.
Also, update the code to use HostInterfaceCache instead of calling Server API.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>