### PR TITLE
change to multistream concheck

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - connection-check
+      - connection-check/**
 
 env:
   IMAGE_VERSION: '1.0.2'

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,14 @@ daemon-secret: ## Modify kustomization files for image pull secret of daemon
 	envsubst < config/samples/patches/image_pull_secret.template > config/samples/patches/image_pull_secret.yaml
 	cd config/samples;$(KUSTOMIZE) edit add patch --path patches/image_pull_secret.yaml
 
+concheck: 
+	kubectl create -f connection-check/concheck.yaml
+
+clean-concheck:
+	kubectl delete -f connection-check/concheck.yaml
+	kubectl delete pod -n default --selector multi-nic-concheck
+	kubectl delete job -n default --selector multi-nic-concheck
+
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)

--- a/connection-check/main.go
+++ b/connection-check/main.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	DEFAULT_NAMESPACE = "default"
+	STREAMS_PER_IP    = 5
 )
 
 func getConfig() *rest.Config {
@@ -45,9 +46,11 @@ func main() {
 	for cidrName, cidr := range cidrMap {
 		podCIDRsMap := cidrHandler.GetPodCIDRsMap(cidr)
 		totalCount := 0
+
 		// create iperf server pod for listed hosts with cidr multi-nic-network
-		for host, _ := range podCIDRsMap {
-			_, err := iperfHanlder.CreateServerPod(DEFAULT_NAMESPACE, cidrName, host)
+		for host, cidrMap := range podCIDRsMap {
+			numberOfInterface := len(cidrMap)
+			_, err := iperfHanlder.CreateServerPod(DEFAULT_NAMESPACE, cidrName, host, numberOfInterface)
 			if err != nil {
 				log.Printf("Cannot create server pod for %s, %s: %v", cidrName, host, err)
 			} else {


### PR DESCRIPTION
This PR changes server and client command generation from single stream to multiple stream for full bandwidth measurement.

Example:

_generated server command_
```yaml
  containers:
  - args:
    - ' (for i in {1..5}; do iperf3 -s -p 501$i & done) &  (for i in {1..5}; do iperf3
      -s -p 502$i & done) & (tail -f /dev/null)'
    command:
    - /bin/sh
    - -c
```
_generated client command_
```yaml
  containers:
  - args:
    - ' (for i in {1..5}; do iperf3 -Z -t 10s -c 192.168.0.1 -p 501$i --connect-timeout
      10s & done  | grep ''receiver'' | awk ''{s+=$7} END{print "192.168.0.1,"s$8}'')
      & (for i in {1..5}; do iperf3 -Z -t 10s -c 192.168.64.1 -p 502$i --connect-timeout
      10s & done  | grep ''receiver'' | awk ''{s+=$7} END{print "192.168.64.1,"s$8}'')
      &wait; sleep 1;echo ''''; (for i in {1..5}; do iperf3 -Z -t 10s -c 192.168.0.65
      -p 501$i --connect-timeout 10s & done  | grep ''receiver'' | awk ''{s+=$7} END{print
      "192.168.0.65,"s$8}'') & (for i in {1..5}; do iperf3 -Z -t 10s -c 192.168.64.65
      -p 502$i --connect-timeout 10s & done  | grep ''receiver'' | awk ''{s+=$7} END{print
      "192.168.64.65,"s$8}'') &wait; sleep 1;echo '''';'
    command:
    - /bin/sh
    - -c
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>