### PR TITLE
Fix bugs causing unsync IPPool

### DIFF
--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -42,6 +42,7 @@ const (
 
 var (
 	OPERATOR_NAMESPACE string = getOperatorNamespace()
+	ConfigReady        bool   = false
 )
 
 func getOperatorNamespace() string {
@@ -154,6 +155,10 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		r.Log.Info(fmt.Sprintf("Cannot get #%v ", err))
 		// Error reading the object - requeue the request.
 		return ctrl.Result{RequeueAfter: ReconcileTime}, nil
+	}
+	if !ConfigReady {
+		r.CIDRHandler.SyncAllPendingCustomCR(r.NetAttachDefHandler)
+		ConfigReady = true
 	}
 
 	dsName := instance.GetName()
@@ -277,14 +282,14 @@ func (r *ConfigReconciler) callFinalizer(reqLogger logr.Logger, dsName string) e
 	}
 	// wait for all ippools deleted
 	for {
-		poolMap, err := r.CIDRHandler.IPPoolHandler.ListIPPool()
-		if err != nil || len(poolMap) == 0 {
+		if err != nil || len(IPPoolCache) == 0 {
 			break
 		}
-		reqLogger.Info(fmt.Sprintf("%d ippools left, wait...", len(poolMap)))
+		reqLogger.Info(fmt.Sprintf("%d ippools left, wait...", len(IPPoolCache)))
 		time.Sleep(1 * time.Second)
 	}
 	// delete CNI deamonset
 	err = r.Clientset.AppsV1().DaemonSets(OPERATOR_NAMESPACE).Delete(context.TODO(), dsName, metav1.DeleteOptions{})
+	ConfigReady = false
 	return nil
 }

--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -35,6 +35,16 @@ const TestModelLabel = "test-mode"
 
 var HostInterfaceCache map[string]multinicv1.HostInterface = make(map[string]multinicv1.HostInterface)
 
+func InitHostInterfaceCache(hostInterfaceHandler *HostInterfaceHandler) error {
+	listObjects, err := hostInterfaceHandler.ListHostInterface()
+	if err == nil {
+		for name, instance := range listObjects {
+			HostInterfaceCache[name] = instance
+		}
+	}
+	return err
+}
+
 //+kubebuilder:rbac:groups=multinic.fms.io,resources=hostinterfaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multinic.fms.io,resources=hostinterfaces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=multinic.fms.io,resources=hostinterfaces/finalizers,verbs=update

--- a/controllers/synchronizer.go
+++ b/controllers/synchronizer.go
@@ -22,6 +22,7 @@ func RunPeriodicUpdate(ticker *time.Ticker, cidrHandler *CIDRHandler, hostInterf
 				}
 				for name, instanceSpec := range CIDRCache {
 					routeStatus := cidrHandler.SyncCIDRRoute(instanceSpec, false)
+					cidrHandler.CleanPendingIPPools(name, instanceSpec)
 					err := cidrHandler.MultiNicNetworkHandler.SyncStatus(name, instanceSpec, routeStatus)
 					if err != nil {
 						logger.Info(fmt.Sprintf("failed to update route status of %s: %v", name, err))

--- a/main.go
+++ b/main.go
@@ -179,8 +179,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	cidrHandler.CleanPreviousCIDR(config, defHandler)
-
 	ticker := time.NewTicker(TICKET_INTERVAL)
 	defer ticker.Stop()
 	syncLog := ctrl.Log.WithName("controllers").WithName("Synchronizer")


### PR DESCRIPTION
This PR fixes the bug where IPPool is not sync with the CIDR.

The issue is a cascading effect from HostInterface cache is not-yet set at CIDR updates when restarting controller after MultiNicNetwork has been already deployed. 
As a result, the previous CIDR entries are all removed as HostInterface become empty and recomputed. The order of PodCIDR of host-interface is FIFO and can be different from the previous assignment. The new PodCIDR can be unexpected assigned to the node that is already running. 

What makes thing worse is that the previously-assigned IPPool is not removed. When daemon assigns the IP, it will pick the first-found IPPool that match that host.

To fix the issue, I add two significant changes.
1. define SyncAllPendingCustomCR to initialize the cache of operator-managed custom resource and sync IPPool to the corresponding CIDR. This function is called once the reconcile loop of Config CR which will be run after manager started. The function UpdateCIDR will be skipped until this function is called.  
2. Update logic to CleanPendingIPPools. Instead of referring to the old CIDR (when update), clean IPPool based on the current CIDR. 

Side update: use IPPoolCache instead of call List API.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>