### PR TITLE
sync active pods at start

### DIFF
--- a/compute/compute.go
+++ b/compute/compute.go
@@ -202,3 +202,26 @@ func (c CIDRCompute) GetCIDRFromByte(cidrInByte [4]byte, subnet string, blocksiz
 	blockSize := int(baseBlock) + blocksize
 	return fmt.Sprintf("%s/%d", bytesToStr(cidrInByte), blockSize)
 }
+
+func (c CIDRCompute) GetIndexInRange(podCIDR string, podIPAddress string) (bool, int) {
+	startPodIP, podNet, _ := net.ParseCIDR(podCIDR)
+	netIP, _, _ := net.ParseCIDR(podIPAddress + "/32")
+	if !podNet.Contains(netIP) {
+		return false, -1
+	}
+	cidrValues := strings.Split(startPodIP.String(), ".")
+	podValues := strings.Split(podIPAddress, ".")
+
+	podIndex := int(0)
+	for index, value := range podValues {
+		if value == cidrValues[index] {
+			continue
+		}
+		cidrValue, _ := strconv.Atoi(cidrValues[index])
+		podValue, _ := strconv.Atoi(podValues[index])
+		diff := podValue - cidrValue
+		diff *= int(math.Pow(256, float64(3-index)))
+		podIndex += int(diff)
+	}
+	return true, podIndex
+}

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -159,6 +159,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if !ConfigReady {
 		r.CIDRHandler.SyncAllPendingCustomCR(r.NetAttachDefHandler)
 		ConfigReady = true
+		r.Log.Info("Set ConfigReady")
 	}
 
 	dsName := instance.GetName()

--- a/controllers/ippool_handler.go
+++ b/controllers/ippool_handler.go
@@ -176,3 +176,13 @@ func (h *IPPoolHandler) checkPoolValidity(excludeCIDRs []string, allocations []m
 	}
 	return invalidAllocations
 }
+
+func (h *IPPoolHandler) AppendIPPoolAllocations(ippoolName string, newAllocations []multinicv1.Allocation) error {
+	ippool, err := h.GetIPPool(ippoolName)
+	if err != nil {
+		return err
+	}
+	patch := client.MergeFrom(ippool.DeepCopy())
+	ippool.Spec.Allocations = append(ippool.Spec.Allocations, newAllocations...)
+	return h.Client.Patch(context.Background(), ippool, patch)
+}

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -109,4 +109,29 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		// Clean up
 		delete(HostInterfaceCache, newHostName)
 	})
+
+	It("Sync CIDR/IPPool", func() {
+		// get index at bytes[3]
+		podCIDR := "192.168.0.0/16"
+		unsyncedIp := "192.168.0.10"
+		contains, index := multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
+		Expect(contains).To(Equal(true))
+		Expect(index).To(Equal(10))
+		// get index at bytes[2]
+		unsyncedIp = "192.168.1.1"
+		contains, index = multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
+		Expect(contains).To(Equal(true))
+		Expect(index).To(Equal(257))
+		// get index at bytes[1]
+		podCIDR = "10.0.0.0/8"
+		unsyncedIp = "10.1.1.1"
+		contains, index = multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
+		Expect(contains).To(Equal(true))
+		Expect(index).To(Equal(256*256 + 256 + 1))
+		// uncontain
+		podCIDR = "192.168.0.0/26"
+		unsyncedIp = "192.168.1.1"
+		contains, index = multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
+		Expect(contains).To(Equal(false))
+	})
 })

--- a/plugin/net_attach_def.go
+++ b/plugin/net_attach_def.go
@@ -27,6 +27,7 @@ const (
 	NET_ATTACH_DEF_API_VERSION = "k8s.cni.cncf.io/v1"
 	NET_ATTACH_DEF_RESOURCE    = "network-attachment-definitions.v1.k8s.cni.cncf.io"
 	NET_ATTACH_DEF_KIND        = "NetworkAttachmentDefinition"
+	StatusesKey                = "k8s.v1.cni.cncf.io/networks-status"
 )
 
 // ////////////////////////////////////////
@@ -73,6 +74,15 @@ type NetConf struct {
 	IsMultiNICIPAM bool        `json:"multiNICIPAM,omitempty"`
 	DaemonIP       string      `json:"daemonIP"`
 	DaemonPort     int         `json:"daemonPort"`
+}
+
+type NetworkStatus struct {
+	Name      string    `json:"name"`
+	Interface string    `json:"interface,omitempty"`
+	IPs       []string  `json:"ips,omitempty"`
+	Mac       string    `json:"mac,omitempty"`
+	Default   bool      `json:"default,omitempty"`
+	DNS       types.DNS `json:"dns,omitempty"`
 }
 
 type NetAttachDefHandler struct {


### PR DESCRIPTION
This PR includes the code to add missing pod allocations in IPPool at the starting point.
The code will list all running pods and check with the allocation list in the IPPool.
It will patch the missing list to the corresponding IPPool CR.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>