### PR TITLE
fix get net-attach-def issue and move generated snapshot to untrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ debug
 
 cache/
 config/default/
+
+live-migration/snapshot

--- a/live-migration/multinicnetwork_l2.yaml
+++ b/live-migration/multinicnetwork_l2.yaml
@@ -3,7 +3,7 @@ kind: MultiNicNetwork
 metadata:
   finalizers:
     - finalizers.multinicnetwork.multinic.fms.io
-  name: multinic-ipvlanl3
+  name: default
 spec:
   ipam: ""
   multiNICIPAM: false


### PR DESCRIPTION
This PR fixes the script error when checking net-attach-def resource and move the generated snapshot to untracked folder.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>