### PR TITLE
improve the script and guideline for operator-sdk installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ namespaces| (optional) limit network definition application to list of namespace
   ```
 ##### installed by bundle with operator-sdk
   ```bash
-  operator-sdk cleanup multi-nic-cni-operator
+  operator-sdk cleanup multi-nic-cni-operator --delete-all
   ```
 

--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z ${OPERATOR_NAMESPACE} ]; then
+    OPERATOR_NAMESPACE=openshift-operators
+fi
+
 _snapshot_resource() {
     dir=$1
     mkdir -p $dir
@@ -13,7 +17,7 @@ _snapshot_resource() {
 _snapshot() {
     dir=$1
     cr=$2
-    itemlist=$(kubectl get $cr -ojson |jq '.items'| jq 'del(.[].metadata.resourceVersion,.[].metadata.uid,.[].metadata.selfLink,.[].metadata.creationTimestamp,.[].metadata.generation,.[].metadata.ownerReferences)') 
+    itemlist=$(kubectl get $cr -ojson |jq '.items'| jq 'del(.[].status,.[].metadata.resourceVersion,.[].metadata.uid,.[].metadata.selfLink,.[].metadata.creationTimestamp,.[].metadata.generation,.[].metadata.ownerReferences)') 
     echo {"apiVersion": "v1", "items": $itemlist, "kind": "List"}| yq eval - -P > $dir/$cr.yaml
 }
 
@@ -22,6 +26,15 @@ activate_cr="multinicnetwork"
 
 get_netname() {
     kubectl get multinicnetwork -ojson|jq .items| jq '.[].metadata.name'| tr -d '"'
+}
+
+get_controller() {
+    kubectl get po -n ${OPERATOR_NAMESPACE}|grep multi-nic-cni-operator-controller-manager|awk '{print $1}'
+}
+
+get_controller_log() {
+    controller=$(get_controller)
+    kubectl logs $controller -n ${OPERATOR_NAMESPACE} -c manager
 }
 
 snapshot() {
@@ -50,13 +63,23 @@ deactivate_route_config() {
 
 uninstall_operator() {
     # uninstall operator
-    kubectl delete subscriptions.operators.coreos.com multi-nic-cni-operator -n openshift-operators
-    kubectl delete clusterserviceversion multi-nic-cni-operator.v1.0.2 -n openshift-operators
-    kubectl delete ds multi-nicd -n openshift-operators
+    kubectl delete subscriptions.operators.coreos.com multi-nic-cni-operator -n $OPERATOR_NAMESPACE
+    kubectl delete clusterserviceversion multi-nic-cni-operator.v1.0.2 -n $OPERATOR_NAMESPACE
+    kubectl delete ds multi-nicd -n $OPERATOR_NAMESPACE
 }
 
 # after reinstall operator
 # deactivate_route_config
+
+patch_daemon() {
+    kubectl patch config.multinic multi-nicd --type merge --patch '{"spec": {"daemon": {"imagePullPolicy": "Always"}}}'
+    kubectl delete po -l app=multi-nicd -n ${OPERATOR_NAMESPACE}
+}
+
+wait_daemon() {
+    echo "Wait for daemonset to be ready"
+    kubectl rollout status daemonset multi-nicd -n ${OPERATOR_NAMESPACE} --timeout 300s
+}
 
 deploy_status_cr() {
     snapshot_dir="snapshot/$1"
@@ -64,6 +87,21 @@ deploy_status_cr() {
     do
         kubectl apply -f $snapshot_dir/$cr.yaml
     done
+}
+
+restart_controller() {
+    controller=$(get_controller)
+    kubectl delete po $controller -n ${OPERATOR_NAMESPACE}
+    echo "Wait for deployment to be available"
+    kubectl wait deployment -n ${OPERATOR_NAMESPACE} multi-nic-cni-operator-controller-manager --for condition=Available=True --timeout=90s
+    ready=$(echo $(get_controller_log)|grep ConfigReady)
+    while [ -z "$ready" ];
+    do
+        sleep 5
+        echo "Wait for config to be ready..."
+        ready=$(echo $(get_controller_log)|grep ConfigReady)
+    done
+    echo "Config Ready"
 }
 
 activate_route_config() {


### PR DESCRIPTION
This PR fixes the typo and wrong function of the previous script to get the net-attach-def. 
Also, improve the script to provide the following utility
- get_controller_log: to get the log of manager container
- daemon_patch: to patch imagePullPolicy: Always for the case that need
- daemon_wait: to check and wait until daemon pods are all ready
- restart_controller: to restart the controller in one line and wait until the config is ready set reading from the manager log
Also, it is adaptable to other installation method such as by operator-sdk by setting custom operator namespace as an env var.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>