### PR TITLE
implement SafeCache

### DIFF
--- a/controllers/daemon_cache_handler.go
+++ b/controllers/daemon_cache_handler.go
@@ -1,0 +1,39 @@
+package controllers
+
+import (
+	"fmt"
+)
+
+type DaemonPod struct {
+	Name      string
+	Namespace string
+	HostIP    string
+	NodeName  string
+	Labels    map[string]string
+}
+
+type DaemonCacheHandler struct {
+	*SafeCache
+}
+
+func (h *DaemonCacheHandler) SetCache(key string, value DaemonPod) {
+	h.SafeCache.SetCache(key, value)
+}
+
+func (h *DaemonCacheHandler) GetCache(key string) (DaemonPod, error) {
+	value := h.SafeCache.GetCache(key)
+	if value == nil {
+		return DaemonPod{}, fmt.Errorf("Not Found")
+	}
+	return value.(DaemonPod), nil
+}
+
+func (h *DaemonCacheHandler) ListCache() map[string]DaemonPod {
+	snapshot := make(map[string]DaemonPod)
+	h.SafeCache.Lock()
+	for key, value := range h.cache {
+		snapshot[key] = value.(DaemonPod)
+	}
+	h.SafeCache.Unlock()
+	return snapshot
+}

--- a/controllers/daemon_connector.go
+++ b/controllers/daemon_connector.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -38,8 +37,8 @@ func SetDaemon(daemonSpec multinicv1.ConfigSpec) {
 }
 
 // GetDaemonAddressByPod returns daemon IP address (pod IP:daemon port)
-func GetDaemonAddressByPod(daemon v1.Pod) string {
-	return fmt.Sprintf("http://%s:%s", daemon.Status.PodIP, DAEMON_PORT)
+func GetDaemonAddressByPod(daemon DaemonPod) string {
+	return fmt.Sprintf("http://%s:%s", daemon.HostIP, DAEMON_PORT)
 }
 
 type DaemonConnector struct {

--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,18 +29,27 @@ type HostInterfaceReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	*DaemonWatcher
+	*HostInterfaceHandler
+	*CIDRHandler
 }
 
 const HostInterfaceReconcileTime = time.Second
+
 const TestModelLabel = "test-mode"
 
-var HostInterfaceCache map[string]multinicv1.HostInterface = make(map[string]multinicv1.HostInterface)
-
-func InitHostInterfaceCache(hostInterfaceHandler *HostInterfaceHandler) error {
+func InitHostInterfaceCache(clientset *kubernetes.Clientset, hostInterfaceHandler *HostInterfaceHandler, daemonCacheHandler *DaemonCacheHandler) error {
 	listObjects, err := hostInterfaceHandler.ListHostInterface()
 	if err == nil {
 		for name, instance := range listObjects {
-			HostInterfaceCache[name] = instance
+			if _, foundErr := daemonCacheHandler.GetCache(name); foundErr != nil {
+				// not found, check whether node is still there.
+				if _, foundErr = clientset.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{}); foundErr != nil {
+					// delete HostInterface and do not add
+					hostInterfaceHandler.DeleteHostInterface(name)
+					continue
+				}
+			}
+			hostInterfaceHandler.SetCache(name, instance)
 		}
 	}
 	return err
@@ -55,16 +65,20 @@ func (r *HostInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// deleted, re-process daemon pods (recreate HostInterface if the daemon pod still exists)
-			r.DaemonWatcher.UpdateCurrentList()
-			r.DaemonWatcher.UpdateCIDRs()
-			delete(HostInterfaceCache, req.Name)
+			// Request object not found, could have been deleted after reconcile request.
+			// Return and don't requeue
+			r.CIDRHandler.UpdateCIDRs()
 			return ctrl.Result{}, nil
 		}
 		// error by other reasons, requeue
 		r.Log.Info(fmt.Sprintf("Requeue HostInterface %s: %v", req.Name, err))
 		return ctrl.Result{RequeueAfter: HostInterfaceReconcileTime}, nil
 	}
+
+	if !ConfigReady || !r.DaemonWatcher.IsDaemonSetReady() {
+		return ctrl.Result{RequeueAfter: ConfigWaitingReconcileTime}, nil
+	}
+
 	r.Log.Info(fmt.Sprintf("HostInterface reconciled: %s", instance.ObjectMeta.Name))
 	err = r.UpdateInterfaces(*instance)
 	if err != nil {
@@ -85,26 +99,25 @@ func (r *HostInterfaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *HostInterfaceReconciler) UpdateInterfaces(instance multinicv1.HostInterface) error {
 	nodeName := instance.Spec.HostName
 	hifName := instance.GetName()
-
-	if pod, ok := DaemonCache[nodeName]; ok {
+	pod, err := r.DaemonWatcher.DaemonCacheHandler.GetCache(nodeName)
+	if err == nil {
 		podAddress := GetDaemonAddressByPod(pod)
 		interfaces, err := r.DaemonWatcher.DaemonConnector.GetInterfaces(podAddress)
 		if err != nil {
 			return err
 		}
-		_, found := HostInterfaceCache[hifName]
-		if !found {
-			HostInterfaceCache[hifName] = *instance.DeepCopy()
-			r.DaemonWatcher.UpdateCIDRs()
+		if !r.HostInterfaceHandler.SafeCache.Contains(hifName) {
+			r.HostInterfaceHandler.SetCache(hifName, *instance.DeepCopy())
+			r.handleUpdatedHostInterface(true)
 		} else if r.interfaceChanged(instance.Spec.Interfaces, interfaces) {
 			r.DaemonWatcher.IpamJoin(pod)
-			updatedHif, err := r.DaemonWatcher.HostInterfaceHandler.UpdateHostInterface(instance, interfaces)
+			updatedHif, err := r.HostInterfaceHandler.UpdateHostInterface(instance, interfaces)
 			if err != nil {
 				return err
 			}
 			r.Log.Info(fmt.Sprintf("%s's interfaces updated", nodeName))
-			HostInterfaceCache[hifName] = *updatedHif.DeepCopy()
-			r.DaemonWatcher.UpdateCIDRs()
+			r.HostInterfaceHandler.SetCache(hifName, *updatedHif.DeepCopy())
+			r.handleUpdatedHostInterface(true)
 		}
 		return nil
 	}
@@ -112,14 +125,28 @@ func (r *HostInterfaceReconciler) UpdateInterfaces(instance multinicv1.HostInter
 		r.Log.Info(fmt.Sprintf("%s on test mode", nodeName))
 		return nil
 	}
-	_, err := r.DaemonWatcher.Clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	_, err = r.DaemonWatcher.Clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		// not found node
 		r.HostInterfaceHandler.DeleteHostInterface(nodeName)
 		r.Log.Info(fmt.Sprintf("Delete Hostinterface %s: node no more exists", nodeName))
 		return nil
 	} else {
-		return fmt.Errorf("no daemon pod found for %s", nodeName)
+		// not found pod even DaemonSet is already ready, node was tainted
+		r.HostInterfaceHandler.DeleteHostInterface(nodeName)
+		r.Log.Info(fmt.Sprintf("Hostinterface %s: no daemon pod found", nodeName))
+		return nil
+	}
+}
+
+func (r *HostInterfaceReconciler) handleUpdatedHostInterface(added bool) {
+	routeChange := r.CIDRHandler.UpdateCIDRs()
+	// call greeting if route changed
+	daemonSnapshot := r.DaemonWatcher.DaemonCacheHandler.ListCache()
+	if added && routeChange {
+		for _, daemon := range daemonSnapshot {
+			r.DaemonWatcher.IpamJoin(daemon)
+		}
 	}
 }
 

--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -34,19 +34,20 @@ type IPPoolReconciler struct {
 
 const ippoolFinalizer = "finalizers.cidr.multinic.fms.io"
 
-var IPPoolCache map[string]multinicv1.IPPoolSpec = make(map[string]multinicv1.IPPoolSpec)
-
 func InitIppoolCache(ippoolHandler *IPPoolHandler) error {
 	listObjects, err := ippoolHandler.ListIPPool()
 	if err == nil {
 		for name, instance := range listObjects {
-			IPPoolCache[name] = instance.Spec
+			ippoolHandler.SetCache(name, instance.Spec)
 		}
 	}
 	return err
 }
 
 func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !ConfigReady {
+		return ctrl.Result{RequeueAfter: ConfigWaitingReconcileTime}, nil
+	}
 	_ = r.Log.WithValues("ippool", req.NamespacedName)
 
 	instance := &multinicv1.IPPool{}
@@ -55,8 +56,6 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Return and don't requeue
-			r.Log.Info(fmt.Sprintf("IPPool %s deleted", instance.GetName()))
-			delete(IPPoolCache, req.Name)
 			return ctrl.Result{}, nil
 		}
 		r.Log.Info(fmt.Sprintf("Cannot get #%v ", err))
@@ -82,7 +81,7 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	} else {
 		ippoolName := instance.GetName()
-		IPPoolCache[ippoolName] = instance.Spec
+		r.CIDRHandler.IPPoolHandler.SetCache(ippoolName, instance.Spec)
 	}
 
 	// Add finalizer to instance
@@ -115,5 +114,6 @@ func (r *IPPoolReconciler) callFinalizer(reqLogger logr.Logger, instance *multin
 		reqLogger.Info(fmt.Sprintf("IPPool %s remains %v allocated", instance.GetName(), remainPods))
 	}
 	reqLogger.Info(fmt.Sprintf("Finalized %s", instance.ObjectMeta.Name))
+	r.CIDRHandler.IPPoolHandler.SafeCache.UnsetCache(instance.ObjectMeta.Name)
 	return nil
 }

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -24,7 +24,8 @@ func updateCIDR(multinicnetwork *multinicv1.MultiNicNetwork, cidr multinicv1.CID
 
 	expectedPodCIDR := 0
 	if changed {
-		for _, hif := range HostInterfaceCache {
+		snapshot := multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.ListCache()
+		for _, hif := range snapshot {
 			for _, iface := range hif.Spec.Interfaces {
 				for _, masterAddresses := range networkAddresses {
 					if iface.NetAddress == masterAddresses {
@@ -77,37 +78,37 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		// Add Host
 		fmt.Println("Add Host")
 		newHostName := "newHost"
-		newHostIndex := len(HostInterfaceCache)
+		newHostIndex := multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SafeCache.GetSize()
 		newHif := generateNewHostInterface(newHostName, interfaceNames, networkPrefixes, newHostIndex)
-		HostInterfaceCache[newHostName] = newHif
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Interface
 		fmt.Println("Add Interface")
 		newInterfaceName := "eth99"
 		newNetworkPrefix := "0.0.0.0"
 		newHif = generateNewHostInterface(newHostName, append(interfaceNames, newInterfaceName), append(networkPrefixes, newNetworkPrefix), newHostIndex)
-		HostInterfaceCache[newHostName] = newHif
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Remove Interface
 		fmt.Println("Remove Interface")
 		newHif = generateNewHostInterface(newHostName, interfaceNames, networkPrefixes, newHostIndex)
-		HostInterfaceCache[newHostName] = newHif
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Interface back
 		fmt.Println("Add Interface Back")
 		newHif = generateNewHostInterface(newHostName, append(interfaceNames, newInterfaceName), append(networkPrefixes, newNetworkPrefix), newHostIndex)
-		HostInterfaceCache[newHostName] = newHif
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Remove Host
 		fmt.Println("Remove Host")
-		delete(HostInterfaceCache, newHostName)
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SafeCache.UnsetCache(newHostName)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Host back
 		fmt.Println("Add Host Back")
-		HostInterfaceCache[newHostName] = newHif
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Clean up
-		delete(HostInterfaceCache, newHostName)
+		multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.SafeCache.UnsetCache(newHostName)
 	})
 
 	It("Sync CIDR/IPPool", func() {

--- a/controllers/safe_cache_handler.go
+++ b/controllers/safe_cache_handler.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"sync"
+)
+
+type SafeCache struct {
+	mu    sync.RWMutex
+	cache map[string]interface{}
+}
+
+func InitSafeCache() *SafeCache {
+	return &SafeCache{
+		cache: make(map[string]interface{}),
+		mu:    sync.RWMutex{},
+	}
+}
+
+func (s *SafeCache) SetCache(key string, value interface{}) {
+	s.mu.Lock()
+	s.cache[key] = value
+	s.mu.Unlock()
+}
+
+func (s *SafeCache) UnsetCache(key string) {
+	s.mu.Lock()
+	delete(s.cache, key)
+	s.mu.Unlock()
+}
+
+func (s *SafeCache) Contains(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.cache[key]
+	return ok
+}
+
+func (s *SafeCache) GetCache(key string) interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if value, ok := s.cache[key]; ok {
+		return value
+	}
+	return nil
+}
+
+func (s *SafeCache) Lock() {
+	s.mu.RLock()
+}
+
+func (s *SafeCache) Unlock() {
+	s.mu.RUnlock()
+}
+
+func (s *SafeCache) GetSize() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.cache)
+}

--- a/plugin/net_attach_def.go
+++ b/plugin/net_attach_def.go
@@ -161,7 +161,7 @@ func (h *NetAttachDefHandler) generate(net *multinicv1.MultiNicNetwork, pluginSt
 	if err != nil {
 		return defs, err
 	}
-	h.Log.Info(fmt.Sprintf("generate config for %v (specify: %d)", namespaces, len(net.Spec.Namespaces)))
+	h.Log.Info(fmt.Sprintf("generate net-attach-def config on %d namespaces", len(namespaces)))
 	for _, ns := range namespaces {
 		name := net.GetName()
 		namespace := ns


### PR DESCRIPTION
This PR is to handle the issue https://github.com/foundation-model-stack/multi-nic-cni/issues/33.

Here the SafeCache struct is implemented for handling any sharing cache including CIDRCache, IPPoolCache, HostInterfaceCache, and DaemonCache. 

Also, to avoid keeping failure on the failed daemon, HostInterface update will be ignored if the daemon pod is missing.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>