### PR TITLE
fix bugs: NotFound check, unexpected hostinterface skip, increase lease duration

### DIFF
--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/foundation-model-stack/multi-nic-cni/compute"
 	"github.com/foundation-model-stack/multi-nic-cni/plugin"
 	"github.com/go-logr/logr"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -312,7 +313,7 @@ func (h *CIDRHandler) updateEntries(cidrSpec multinicv1.CIDRSpec, excludes []com
 				if _, died := diedHost[host.HostName]; died {
 					changed = true
 				} else {
-					if _, foundErr := h.Clientset.CoreV1().Nodes().Get(context.TODO(), host.HostName, metav1.GetOptions{}); foundErr != nil {
+					if _, foundErr := h.Clientset.CoreV1().Nodes().Get(context.TODO(), host.HostName, metav1.GetOptions{}); foundErr != nil && k8serr.IsNotFound(foundErr) {
 						// host died
 						h.Log.Info(fmt.Sprintf("Host %s no longer exist, delete from entry of CIDR %s", host.HostName, cidrSpec.Config.Name))
 						// host not exist anymore

--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -67,7 +67,7 @@ func (r *HostInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Return and don't requeue
-			r.CIDRHandler.UpdateCIDRs()
+			r.UpdateCIDRs()
 			return ctrl.Result{}, nil
 		}
 		// error by other reasons, requeue
@@ -108,8 +108,8 @@ func (r *HostInterfaceReconciler) UpdateInterfaces(instance multinicv1.HostInter
 		}
 		if !r.HostInterfaceHandler.SafeCache.Contains(hifName) {
 			r.HostInterfaceHandler.SetCache(hifName, *instance.DeepCopy())
-			r.handleUpdatedHostInterface(true)
-		} else if r.interfaceChanged(instance.Spec.Interfaces, interfaces) {
+		}
+		if r.interfaceChanged(instance.Spec.Interfaces, interfaces) {
 			r.DaemonWatcher.IpamJoin(pod)
 			updatedHif, err := r.HostInterfaceHandler.UpdateHostInterface(instance, interfaces)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -66,6 +66,9 @@ func main() {
 
 	config := ctrl.GetConfigOrDie()
 
+	leaseDuration := 30 * time.Second
+	renewDeadline := 20 * time.Second
+
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -73,7 +76,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "5aaf67fd.fms.io",
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
 	})
+
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
As the error for get API is not always `NotFound` , this PR is to make sure that the host added to the died list (to be removed from CIDR) is not found.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>