### PR TITLE
change VERSION to v1.0.3

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -16,7 +16,7 @@ on:
       - ./Makefile
 
 env:
-  IMAGE_VERSION: '1.0.2'
+  VERSION: '1.0.3'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
@@ -59,7 +59,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+            ${{ env.IMAGE_NAME }}:v${{ env.VERSION }}
           file: ./bundle.Dockerfile
          
   build-push-controller:
@@ -91,5 +91,5 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
             ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+            ${{ env.IMAGE_NAME }}:v${{ env.VERSION }}
           file: ./Dockerfile

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -9,7 +9,7 @@ on:
       - cni/**
       
 env:
-  IMAGE_VERSION: '1.0.2'
+  IMAGE_VERSION: '1.0.3'
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # VERSION ?= 0.0.1
-VERSION ?= 1.0.2
+VERSION ?= 1.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
-  newTag: v1.0.2
+  newTag: v1.0.0

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -12,4 +12,4 @@ kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
-  newTag: v1.0.2
+  newTag: v1.0.0

--- a/connection-check/makefile
+++ b/connection-check/makefile
@@ -6,8 +6,8 @@
 export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
 
 IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/multi-nic-cni
-VERSION ?= 1.0.2
-CONCHECK_IMG ?= $(IMAGE_TAG_BASE)-concheck:v$(VERSION)
+IMAGE_VERSION ?= 1.0.0
+CONCHECK_IMG ?= $(IMAGE_TAG_BASE)-concheck:v$(IMAGE_VERSION)
 
 
 docker-build:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -212,8 +212,7 @@ var _ = BeforeSuite(func() {
 			AddRoutePath:    "/addroute",
 			DeleteRoutePath: "/deleteroute",
 			Daemon: multinicv1.DaemonSpec{
-				Image:           "res-cpe-team-docker-local.artifactory.swg-devops.com/net/multi-nic-cni-daemon:v1.0.0-alpha",
-				ImagePullSecret: "multi-nic-cni-operator-res-cpe-team-docker-local",
+				Image:           "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.0.2",
 				ImagePullPolicy: "Always",
 				SecurityContext: &v1.SecurityContext{
 					Privileged: &trueValue,

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,8 +6,8 @@ export DAEMON_REGISTRY ?= ghcr.io/foundation-model-stack
 
 # DAEMON_IMG defines the image:tag used for daemon
 IMAGE_TAG_BASE = $(DAEMON_REGISTRY)/multi-nic-cni
-VERSION ?= 1.0.2
-DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v$(VERSION)
+IMAGE_VERSION ?= 1.0.0
+DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v$(IMAGE_VERSION)
 
 
 test-verbose:


### PR DESCRIPTION
This PR changes development version to 1.0.3.
remove redundant environment name of VERSION and IMAGE_VERSION.

Notes:
- keep concheck version 1.0.2
- keep version 1.0.2 in instruction and sample
- daemon/cni use IMAGE_VERSION
- operator use VERSION

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>