### PR TITLE
add IsNotFound check

### DIFF
--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -284,7 +284,7 @@ func (r *ConfigReconciler) callFinalizer(reqLogger logr.Logger, dsName string) e
 
 	// delete all CIDRs
 	cidrMap, err := r.CIDRHandler.ListCIDR()
-	if err != nil {
+	if err == nil {
 		for _, cidr := range cidrMap {
 			r.CIDRHandler.DeleteCIDR(cidr)
 		}

--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -126,7 +126,7 @@ func (r *HostInterfaceReconciler) UpdateInterfaces(instance multinicv1.HostInter
 		return nil
 	}
 	_, err = r.DaemonWatcher.Clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && errors.IsNotFound(err) {
 		// not found node
 		r.HostInterfaceHandler.DeleteHostInterface(nodeName)
 		r.Log.Info(fmt.Sprintf("Delete Hostinterface %s: node no more exists", nodeName))


### PR DESCRIPTION
This PR is to fix the bug point when the error from kubernetes API is not expected `NotFound` error. 
This bug could cause a serious result in losing the main CIDR information such as reported in https://github.com/foundation-model-stack/multi-nic-cni/issues/46.

This PR also fix the minor bug to delete CIDR resources when cleaning the config resource too.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>