### PR TITLE
Fix nil reference and handle hostname with prefix,suffix

### DIFF
--- a/daemon/src/allocator/allocator.go
+++ b/daemon/src/allocator/allocator.go
@@ -8,10 +8,6 @@ package allocator
 import (
 	"context"
 	"fmt"
-	"github.com/foundation-model-stack/multi-nic-cni/daemon/backend"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"log"
 	"math"
 	"sort"
@@ -19,6 +15,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/foundation-model-stack/multi-nic-cni/daemon/backend"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -193,7 +194,7 @@ func AllocateIP(req IPRequest) []IPResponse {
 			break
 		}
 		spec := ippoolSpecMap[ippoolName]
-		if spec.NetAttachDefName == defName && spec.HostName == hostName {
+		if spec.NetAttachDefName == defName && strings.Contains(spec.HostName, hostName) {
 			deleteIndex := -1
 			for deleteIndex = 0; deleteIndex < len(interfaceNames); deleteIndex++ {
 				interfaceName := interfaceNames[deleteIndex]
@@ -293,7 +294,7 @@ func CleanHangingAllocation(hostName string) error {
 	}
 	for ippoolName, _ := range ippoolSpecMap {
 		spec := ippoolSpecMap[ippoolName]
-		if spec.HostName == hostName {
+		if strings.Contains(spec.HostName, hostName) {
 			allocations := spec.Allocations
 			remains := []backend.Allocation{}
 			for _, allocation := range allocations {
@@ -335,7 +336,7 @@ func DeallocateIP(req IPRequest) []IPResponse {
 	}
 	for ippoolName, _ := range ippoolSpecMap {
 		spec := ippoolSpecMap[ippoolName]
-		if spec.NetAttachDefName == defName && spec.HostName == hostName {
+		if spec.NetAttachDefName == defName && strings.Contains(spec.HostName, hostName) {
 			allocations := spec.Allocations
 
 			for index, allocation := range allocations {


### PR DESCRIPTION
This PR fixes mentioned in the issue https://github.com/foundation-model-stack/multi-nic-cni/issues/56. 
- need to also check nil value of route.Dst 
```go
		if route.Gw != nil && cmpRoute.Gw != nil && route.Dst != nil && cmpRoute.Dst != nil {
			if route.Dst.String() == cmpRoute.Dst.String() && route.Gw.String() == cmpRoute.Gw.String() {
				return true, nil
			}
```
- In AWS machine, as nodename contains suffix of zone (e.g., ap-northeast-1.compute.internal), use `Contains` function intead of `=`.
```bash
> uname -n
ip-10-0-143-42 # nodename = ip-10-0-143-42.ap-northeast-1.compute.internal
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>