### PR TITLE
Add aws-ipvlan plugin to multi-nic-cni

### DIFF
--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - daemon/**
       - cni/**
+      - Makefile
       
 env:
   IMAGE_VERSION: '1.0.3'
@@ -22,6 +23,8 @@ jobs:
           go-version: '1.17.0'
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
+      - name: Test
+        run: make test-daemon
       - name: Update CNI
         run: make update-cni-local
         working-directory: daemon
@@ -41,7 +44,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
-          file: ./daemon/Dockerfile
+          file: ./daemon/dockerfiles/Dockerfile
       - name: Build and push daemon (dirty)
         if: ${{ github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v2
@@ -50,4 +53,4 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}-dirty
-          file: ./daemon/Dockerfile
+          file: ./daemon/dockerfiles/Dockerfile

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -2,8 +2,6 @@ name: Build and push daemon image
 
 on:
   push:
-    branches:
-      - main
     paths:
       - daemon/**
       - cni/**
@@ -22,11 +20,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17.0'
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
       - name: Update CNI
         run: make update-cni-local
         working-directory: daemon
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v1
       - name: Login to Docker
         uses: docker/login-action@v1
         with:
@@ -34,6 +32,7 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push daemon
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v2
         with:
           context: daemon
@@ -42,4 +41,13 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./daemon/Dockerfile
+      - name: Build and push daemon (dirty)
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: daemon
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}-dirty
           file: ./daemon/Dockerfile

--- a/Dockerfile.multinicd-test
+++ b/Dockerfile.multinicd-test
@@ -27,6 +27,8 @@ COPY cni/plugins/main/multi-nic cni/plugins/main/multi-nic
 RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic ./plugins/main/multi-nic
 COPY cni/plugins/ipam cni/plugins/ipam
 RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+COPY cni/plugins/main/aws-ipvlan cni/plugins/main/aws-ipvlan
+RUN cd cni && go mod tidy && go build -o /usr/local/app/aws-ipvlan ./plugins/main/aws-ipvlan
 RUN cd cni && make ginkgo-set
 RUN cd daemon/src && go build -o /usr/local/app/daemon
 RUN cp /usr/local/app/multi-nic /usr/local/bin \ 

--- a/Dockerfile.multinicd-test
+++ b/Dockerfile.multinicd-test
@@ -1,0 +1,37 @@
+FROM ubuntu:20.04
+
+RUN  apt-get update \
+  && apt-get install -y wget tar build-essential net-tools iproute2 git curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# install go
+RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+ENV PATH "/usr/local/go/bin:${PATH}"
+RUN mkdir -p /usr/local/app
+RUN mkdir -p /usr/local/build
+RUN mkdir -p /host/opt/cni/bin
+WORKDIR /usr/local/build
+RUN curl -sSLo kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz \
+  && tar -zxvf kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz
+RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
+COPY daemon daemon
+RUN mkdir -p daemon/src/test-bin
+RUN mv kubebuilder_2.0.0-alpha.1_linux_amd64 daemon/src/test-bin/kubebuilder && mv setup-envtest.sh daemon/src/test-bin/setup-envtest.sh
+RUN cd daemon/src && go mod tidy 
+RUN mkdir -p cni
+COPY cni/go.mod cni/go.mod
+COPY cni/Makefile cni/Makefile
+RUN cd cni && make plugins-set
+COPY cni/pkg cni/pkg
+COPY cni/plugins/main/multi-nic cni/plugins/main/multi-nic
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic ./plugins/main/multi-nic
+COPY cni/plugins/ipam cni/plugins/ipam
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+RUN cd cni && make ginkgo-set
+RUN cd daemon/src && go build -o /usr/local/app/daemon
+RUN cp /usr/local/app/multi-nic /usr/local/bin \ 
+&& cp /usr/local/app/multi-nic-ipam /usr/local/bin \
+&& cp /usr/local/app/aws-ipvlan /usr/local/bin
+WORKDIR /usr/local/app
+COPY daemon/run.sh run.sh
+CMD ["/bin/bash", "run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -239,4 +239,7 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-
+test-daemon:
+	docker build -t daemon-test:latest -f Dockerfile.multinicd-test .
+	docker run -it --privileged daemon-test /bin/bash -c "cd /usr/local/build/cni&&make test"
+	docker run -it --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,10 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 test-daemon:
-	docker build -t daemon-test:latest -f Dockerfile.multinicd-test .
-	docker run -it --privileged daemon-test /bin/bash -c "cd /usr/local/build/cni&&make test"
-	docker run -it --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"
+	docker build -t daemon-test:latest -f ./daemon/dockerfiles/Dockerfile.multi-nicd-test .
+	docker run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/cni&&make test"
+	docker run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"
+
+build-push-kbuilder-base:
+	docker build -t $(IMAGE_TAG_BASE)-kbuilder -f ./daemon/dockerfiles/Dockerfile.kbuilder .
+	docker push $(IMAGE_TAG_BASE)-kbuilder

--- a/cni/Makefile
+++ b/cni/Makefile
@@ -46,6 +46,7 @@ build: plugins-set tidy
 	@mkdir -p bin
 	@go build -o bin/multi-nic ./plugins/main/multi-nic
 	@go build -o bin/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+	@go build -o bin/aws-ipvlan ./plugins/main/aws-ipvlan
 
 build-with-test: test build
 

--- a/cni/Makefile
+++ b/cni/Makefile
@@ -6,16 +6,20 @@ all: build copy-to-daemon
 
 ENVTEST_ASSETS_DIR=$(PWD)/test-bin
 export PATH := $(PATH):$(PWD)/test-bin
-export GOPATH := $(HOME)/go
 
-get-ginkgo:
-	@go get -u github.com/onsi/ginkgo/ginkgo && go install github.com/onsi/ginkgo/ginkgo && \
-	 go get -u github.com/onsi/gomega/... && go install github.com/onsi/gomega/... && \
-	 mkdir -p ${ENVTEST_ASSETS_DIR} && \
-	 cp $(GOPATH)/bin/ginkgo $(ENVTEST_ASSETS_DIR)/ginkgo
+ifndef GOPATH
+  GOPATH := $(HOME)/go
+  GOBIN := $(GOPATH)/bin
+endif
 
-ginkgo-set:
-	@test -f $(ENVTEST_ASSETS_DIR)/ginkgo || ($(MAKE) get-ginkgo)
+
+ginkgo-set: tidy
+	mkdir -p $(GOBIN)
+	mkdir -p ${ENVTEST_ASSETS_DIR}
+	@test -f $(ENVTEST_ASSETS_DIR)/ginkgo || \
+	 (go install -mod=mod github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
+	  cp $(GOBIN)/ginkgo $(ENVTEST_ASSETS_DIR)/ginkgo)
+	
 
 get-plugins:
 	@cd /tmp && \

--- a/cni/Makefile
+++ b/cni/Makefile
@@ -42,7 +42,7 @@ tidy:
 test: ginkgo-set plugins-set
 	@cd ./plugins/main/multi-nic && ginkgo
 
-build: plugins-set tidy
+build: tidy
 	@mkdir -p bin
 	@go build -o bin/multi-nic ./plugins/main/multi-nic
 	@go build -o bin/multi-nic-ipam ./plugins/ipam/multi-nic-ipam

--- a/cni/go.mod
+++ b/cni/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/safchain/ethtool v0.1.0
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+	go.uber.org/zap v1.10.0
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
 require (

--- a/cni/go.mod
+++ b/cni/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/safchain/ethtool v0.1.0
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+	github.com/aws/aws-sdk-go v1.43.29
 	go.uber.org/zap v1.10.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/cni/pkg/ipam/ipam.go
+++ b/cni/pkg/ipam/ipam.go
@@ -16,6 +16,7 @@ package ipam
 
 import (
 	"context"
+
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/types"
 )
@@ -30,4 +31,9 @@ func ExecCheck(plugin string, netconf []byte) error {
 
 func ExecDel(plugin string, netconf []byte) error {
 	return invoke.DelegateDel(context.TODO(), plugin, netconf, nil)
+}
+
+func ExecDelWithResult(plugin string, netconf []byte) (types.Result, error) {
+	// modified function to also return result
+	return DelegateDel(context.TODO(), plugin, netconf, nil)
 }

--- a/cni/pkg/ipam/ipam_invoke.go
+++ b/cni/pkg/ipam/ipam_invoke.go
@@ -1,0 +1,61 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+var defaultExec = &invoke.DefaultExec{
+	RawExec: &invoke.RawExec{Stderr: os.Stderr},
+}
+
+func delegateCommon(delegatePlugin string, exec invoke.Exec) (string, invoke.Exec, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
+	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return pluginPath, exec, nil
+}
+
+// DelegateDel calls the given delegate plugin with the CNI DEL action and
+// JSON configuration
+func DelegateDel(ctx context.Context, delegatePlugin string, netconf []byte, exec invoke.Exec) (types.Result, error) {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return nil, err
+	}
+
+	// DelegateDel will override the original CNI_COMMAND env from process with DEL
+	return invoke.ExecPluginWithResult(ctx, pluginPath, netconf, delegateArgs("DEL"), realExec)
+}
+
+// return CNIArgs used by delegation
+func delegateArgs(action string) *invoke.DelegateArgs {
+	return &invoke.DelegateArgs{
+		Command: action,
+	}
+}

--- a/cni/pkg/utils/logger.go
+++ b/cni/pkg/utils/logger.go
@@ -1,0 +1,43 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	logLevel = zapcore.DebugLevel
+)
+
+var Logger *zap.Logger
+
+func InitializeLogger(logFilePath string) {
+	config := zap.NewProductionEncoderConfig()
+	config.EncodeTime = zapcore.ISO8601TimeEncoder
+	fileEncoder := zapcore.NewJSONEncoder(config)
+	writer := zapcore.AddSync(&lumberjack.Logger{
+		Filename:   logFilePath,
+		MaxSize:    500, // megabytes
+		MaxBackups: 3,
+		MaxAge:     28, // days
+	})
+	core := zapcore.NewTee(
+		zapcore.NewCore(fileEncoder, writer, logLevel),
+	)
+	Logger = zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+}

--- a/cni/plugins/main/aws-ipvlan/aws-ipvlan.go
+++ b/cni/plugins/main/aws-ipvlan/aws-ipvlan.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
+
+	"github.com/containernetworking/plugins/pkg/utils"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
+)
+
+const (
+	logFilePath = "/var/log/multi-nic-aws-ipvlan.log"
+)
+
+// NetConf defines general config for multi-nic-cni
+type NetConf struct {
+	types.NetConf
+	PrimaryIP string `json:"primaryIP"`
+	PodIP     string `json:"podIP"`
+	Master    string `json:"master"`
+	Mode      string `json:"mode"`
+	MTU       int    `json:"mtu"`
+}
+
+type IPVLANTypeNetConf struct {
+	types.NetConf
+	IPAM   IPAMConfig `json:"ipam"`
+	Master string     `json:"master"`
+	Mode   string     `json:"mode"`
+	MTU    int        `json:"mtu"`
+}
+
+// static IPAM
+type Address struct {
+	AddressStr string `json:"address"`
+	Gateway    net.IP `json:"gateway,omitempty"`
+	Address    net.IPNet
+	Version    string
+}
+
+type IPAMConfig struct {
+	Name      string
+	Type      string    `json:"type"`
+	Addresses []Address `json:"addresses,omitempty"`
+}
+
+func main() {
+	utils.InitializeLogger(logFilePath)
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("multi-nic"))
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	// load general NetConf and get deviceType
+	n, ipvlanConfig, err := loadConf(args, false)
+	if err != nil {
+		return fmt.Errorf("failed to load netconf: %v", err)
+	}
+	utils.Logger.Debug(fmt.Sprintf("Received an ADD request for: conf=%v", n))
+	_, err = AssignIP(n.PrimaryIP, n.PodIP)
+	if err != nil {
+		return fmt.Errorf("Failed to AssignIP: %v", err)
+	}
+	// call ipvlan
+	command := "ADD"
+	executeResult, err := execIPVLAN(command, ipvlanConfig, args, args.IfName, true)
+	defer func() {
+		if err != nil {
+			unassignErr := UnassignIP(n.PrimaryIP, n.PodIP)
+			if unassignErr != nil {
+				utils.Logger.Debug(fmt.Sprintf("Unassign %s from %s failed: %v", n.PodIP, n.PrimaryIP, unassignErr))
+			}
+		}
+	}()
+	if err != nil {
+		return err
+	}
+	return types.PrintResult(executeResult, n.CNIVersion)
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	if args.Netns == "" {
+		return nil
+	}
+	n, ipvlanConfig, err := loadConf(args, false)
+	if err != nil {
+		return fmt.Errorf("fail to load conf: %v", err)
+	}
+	utils.Logger.Debug(fmt.Sprintf("Received an DEL request for: conf=%v", n))
+	err = UnassignIP(n.PrimaryIP, n.PodIP)
+	if err != nil {
+		return fmt.Errorf("Failed to UnassignIP: %v", err)
+	}
+	// call ipvlan
+	command := "DEL"
+	_, err = execIPVLAN(command, ipvlanConfig, args, args.IfName, false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func cmdCheck(args *skel.CmdArgs) error {
+	if args.Netns == "" {
+		return nil
+	}
+	_, ipvlanConfig, err := loadConf(args, false)
+	if err != nil {
+		return fmt.Errorf("fail to load conf: %v", err)
+	}
+	// call ipvlan
+	command := "CHECK"
+	_, err = execIPVLAN(command, ipvlanConfig, args, args.IfName, false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadConf unmarshal NetConf and return with dev type
+func loadConf(args *skel.CmdArgs, check bool) (*NetConf, *IPVLANTypeNetConf, error) {
+	n := &NetConf{}
+	if err := json.Unmarshal(args.StdinData, n); err != nil {
+		return nil, nil, err
+	}
+	ipvlanConfig := &IPVLANTypeNetConf{}
+	if err := json.Unmarshal(args.StdinData, ipvlanConfig); err != nil {
+		return nil, nil, err
+	}
+	return n, ipvlanConfig, nil
+}
+
+var defaultExec = &invoke.DefaultExec{
+	RawExec: &invoke.RawExec{Stderr: os.Stderr},
+}
+
+func execIPVLAN(command string, ipvlanConfig *IPVLANTypeNetConf, args *skel.CmdArgs, ifName string, isAdd bool) (*current.Result, error) {
+	confBytes, err := json.Marshal(ipvlanConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ipvlanConfig: %v", err)
+	}
+	cniPath := os.Getenv("CNI_PATH")
+	singleNicArgs := &invoke.Args{
+		Command:       command,
+		ContainerID:   args.ContainerID,
+		NetNS:         args.Netns,
+		IfName:        ifName,
+		PluginArgsStr: args.Args,
+		Path:          cniPath,
+	}
+	paths := filepath.SplitList(cniPath)
+	pluginPath, err := defaultExec.FindInPath("ipvlan", paths)
+	if err != nil {
+		return nil, err
+	}
+
+	if isAdd {
+		r, err := invoke.ExecPluginWithResult(context.TODO(), pluginPath, confBytes, singleNicArgs, defaultExec)
+		if err != nil {
+			return nil, err
+		}
+		return current.NewResultFromResult(r)
+	} else {
+		err = invoke.ExecPluginWithoutResult(context.TODO(), pluginPath, confBytes, singleNicArgs, defaultExec)
+		return nil, err
+	}
+}

--- a/cni/plugins/main/aws-ipvlan/aws_util.go
+++ b/cni/plugins/main/aws-ipvlan/aws_util.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	ec2svc "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/containernetworking/plugins/pkg/utils"
+)
+
+const (
+	maxRetries  = 5
+	handlerName = "multi-nic-aws"
+)
+
+var (
+	httpTimeoutValue = 10 * time.Second
+)
+
+// EC2 is the EC2 wrapper interface
+type EC2 interface {
+	DescribeNetworkInterfacesWithContext(ctx aws.Context, input *ec2svc.DescribeNetworkInterfacesInput, opts ...request.Option) (*ec2svc.DescribeNetworkInterfacesOutput, error)
+
+	AssignPrivateIpAddressesWithContext(ctx aws.Context, input *ec2svc.AssignPrivateIpAddressesInput, opts ...request.Option) (*ec2svc.AssignPrivateIpAddressesOutput, error)
+	UnassignPrivateIpAddressesWithContext(ctx aws.Context, input *ec2svc.UnassignPrivateIpAddressesInput, opts ...request.Option) (*ec2svc.UnassignPrivateIpAddressesOutput, error)
+}
+
+func getClient() (EC2, error) {
+	sess := session.New()
+	ec2Metadata := ec2metadata.New(sess)
+	region, err := ec2Metadata.Region()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get region: %v", err)
+	}
+
+	cfg := aws.NewConfig().WithRegion(region)
+	sess = sess.Copy(cfg)
+	client := ec2svc.New(sess)
+	return client, nil
+}
+
+func getENIId(client EC2, primaryAddress string) (*string, error) {
+	input := &ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("addresses.private-ip-address"),
+				Values: []*string{aws.String(primaryAddress)},
+			},
+		},
+	}
+	output, err := client.DescribeNetworkInterfacesWithContext(context.Background(), input)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to DescribeNetworkInterfaces: %v", err)
+	}
+	if len(output.NetworkInterfaces) == 0 {
+		return nil, fmt.Errorf("Cannot getENIId: no interface found")
+	}
+	eniID := output.NetworkInterfaces[0].NetworkInterfaceId
+	return eniID, err
+}
+
+func AssignIP(primaryAddress, podIP string) (*ec2svc.AssignPrivateIpAddressesOutput, error) {
+	client, err := getClient()
+	if client == nil {
+		return nil, err
+	}
+	eniId, err := getENIId(client, primaryAddress)
+	if err != nil {
+		return nil, err
+	}
+	input := &ec2.AssignPrivateIpAddressesInput{
+		AllowReassignment:  aws.Bool(true),
+		NetworkInterfaceId: eniId,
+		PrivateIpAddresses: []*string{
+			aws.String(podIP),
+		},
+	}
+	utils.Logger.Debug(fmt.Sprintf("AssignPrivateIpAddresses %s to %s", podIP, *eniId))
+	output, err := client.AssignPrivateIpAddressesWithContext(context.Background(), input)
+	return output, err
+}
+
+func UnassignIP(primaryAddress, podIP string) error {
+	client, err := getClient()
+	if client == nil {
+		return err
+	}
+	eniId, err := getENIId(client, primaryAddress)
+	if err != nil {
+		return err
+	}
+	input := &ec2.UnassignPrivateIpAddressesInput{
+		NetworkInterfaceId: eniId,
+		PrivateIpAddresses: []*string{
+			aws.String(podIP),
+		},
+	}
+	utils.Logger.Debug(fmt.Sprintf("UnassignPrivateIpAddresses %s from %s", podIP, *eniId))
+	_, err = client.UnassignPrivateIpAddressesWithContext(context.Background(), input)
+	return err
+}

--- a/cni/plugins/main/multi-nic/aws-ipvlan.go
+++ b/cni/plugins/main/multi-nic/aws-ipvlan.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/utils"
+	"github.com/vishvananda/netlink"
+)
+
+func getHostIP(devName string) net.IP {
+	devLink, err := netlink.LinkByName(devName)
+	if err != nil {
+		utils.Logger.Debug(fmt.Sprintf("cannot find link %s: %v", devName, err))
+		return nil
+	}
+	addrs, err := netlink.AddrList(devLink, netlink.FAMILY_V4)
+	if err != nil || len(addrs) == 0 {
+		utils.Logger.Debug(fmt.Sprintf("cannot list address on %s: %v", devName, err))
+		return nil
+	}
+	return addrs[0].IPNet.IP.To4()
+}
+
+type AWSIPVLANNetConfig struct {
+	types.NetConf
+	MainPlugin AWSIPVLANNetConf `json:"plugin"`
+}
+
+type AWSIPVLANNetConf struct {
+	types.NetConf
+	PrimaryIP string `json:"primaryIP"`
+	PodIP     string `json:"podIP"`
+	Master    string `json:"master"`
+	Mode      string `json:"mode"`
+	MTU       int    `json:"mtu"`
+}
+
+// loadAWSCNIConf unmarshal to AWSCNINetConfig and returns list of AWSCNI configs
+func loadAWSCNIConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*current.IPConfig) ([][]byte, error) {
+	confBytesArray := [][]byte{}
+
+	configInAWSIPVLAN := &AWSIPVLANNetConfig{}
+	if err := json.Unmarshal(bytes, configInAWSIPVLAN); err != nil {
+		return confBytesArray, fmt.Errorf("unmarshal AWSIPVLANNetConfig: %v", err)
+	}
+
+	// interfaces are orderly assigned from interface set
+	for index, masterName := range n.Masters {
+		// add config
+		singleConfig, err := copyAWSIPVLANConfig(configInAWSIPVLAN.MainPlugin)
+		if err != nil {
+			return confBytesArray, fmt.Errorf("copyAWSIPVLANConfig: %v", err)
+		}
+		if singleConfig.CNIVersion == "" {
+			singleConfig.CNIVersion = n.CNIVersion
+		}
+		singleConfig.Name = fmt.Sprintf("%s-%d", ifName, index)
+		singleConfig.Master = masterName
+		confBytes, err := json.Marshal(singleConfig)
+		if err != nil {
+			return confBytesArray, fmt.Errorf("Marshal confBytes: %v", err)
+		}
+		// add primary IP value
+		nodeIP := getHostIP(masterName)
+		primaryIP := nodeIP.String()
+		confBytes = injectPrimaryIP(confBytes, primaryIP)
+		if n.IsMultiNICIPAM {
+			// multi-NIC IPAM config
+			if index < len(ipConfigs) {
+				confBytes = injectMultiNicIPAM(confBytes, ipConfigs, index)
+				podIP := ipConfigs[index].Address.IP.String()
+				// add pod IP value
+				confBytes = injectPodIP(confBytes, podIP)
+				confBytesArray = append(confBytesArray, confBytes)
+			} else {
+				utils.Logger.Debug(fmt.Sprintf("index not match config %d, %v", index, ipConfigs))
+			}
+		} else {
+			confBytes = injectSingleNicIPAM(confBytes, bytes)
+			confBytesArray = append(confBytesArray, confBytes)
+			// TO-DO: get IP and inject podIP
+		}
+	}
+	return confBytesArray, nil
+}
+
+func injectPodIP(confBytes []byte, podIP string) []byte {
+	confStr := string(confBytes)
+	replaceValue := fmt.Sprintf("\"podIP\":\"%s\"", podIP)
+	injectedStr := strings.ReplaceAll(confStr, "\"podIP\":\"\"", replaceValue)
+	return []byte(injectedStr)
+}
+
+func injectPrimaryIP(confBytes []byte, primaryIP string) []byte {
+	confStr := string(confBytes)
+	replaceValue := fmt.Sprintf("\"primaryIP\":\"%s\"", primaryIP)
+	injectedStr := strings.ReplaceAll(confStr, "\"primaryIP\":\"\"", replaceValue)
+	return []byte(injectedStr)
+}
+
+// copyAWSIPVLANConfig makes a copy of AWS IPVLAN config
+func copyAWSIPVLANConfig(original AWSIPVLANNetConf) (*AWSIPVLANNetConf, error) {
+	copiedObject := &AWSIPVLANNetConf{}
+	byteObject, err := json.Marshal(original)
+	if err != nil {
+		return copiedObject, err
+	}
+	err = json.Unmarshal(byteObject, copiedObject)
+	if err != nil {
+		return copiedObject, err
+	}
+	return copiedObject, nil
+}

--- a/cni/plugins/main/multi-nic/exec.go
+++ b/cni/plugins/main/multi-nic/exec.go
@@ -2,13 +2,14 @@
  * Copyright 2022- IBM Inc. All rights reserved
  * SPDX-License-Identifier: Apache2.0
  */
- 
+
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
-	"context"
+
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 
@@ -19,23 +20,23 @@ var defaultExec = &invoke.DefaultExec{
 	RawExec: &invoke.RawExec{Stderr: os.Stderr},
 }
 
-func execPlugin(plugin string, command string, confBytes []byte, args *skel.CmdArgs, ifName string, isAdd bool) (*current.Result, error) {
+func execPlugin(plugin string, command string, confBytes []byte, args *skel.CmdArgs, ifName string, withResult bool) (*current.Result, error) {
 	cniPath := os.Getenv("CNI_PATH")
 	singleNicArgs := &invoke.Args{
-		Command: command,
-		ContainerID: args.ContainerID,
-		NetNS: args.Netns,
-		IfName: ifName,
+		Command:       command,
+		ContainerID:   args.ContainerID,
+		NetNS:         args.Netns,
+		IfName:        ifName,
 		PluginArgsStr: args.Args,
-		Path: cniPath,
+		Path:          cniPath,
 	}
 	paths := filepath.SplitList(cniPath)
 	pluginPath, err := defaultExec.FindInPath(plugin, paths)
 	if err != nil {
 		return nil, err
 	}
- 	
-	if isAdd {
+
+	if withResult {
 		r, err := invoke.ExecPluginWithResult(context.TODO(), pluginPath, confBytes, singleNicArgs, defaultExec)
 		if err != nil {
 			return nil, err

--- a/cni/plugins/main/multi-nic/multi-nic.go
+++ b/cni/plugins/main/multi-nic/multi-nic.go
@@ -2,14 +2,14 @@
  * Copyright 2022- IBM Inc. All rights reserved
  * SPDX-License-Identifier: Apache2.0
  */
- 
+
 package main
 
 import (
-	"os"
-	"net"
 	"encoding/json"
 	"fmt"
+	"net"
+	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -18,9 +18,8 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/utils"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
-
-
 )
 
 const (
@@ -28,37 +27,37 @@ const (
 	DEFAULT_SUBNET          = "172.30.0.0/16"
 	DEFAULT_HOST_BLOCK      = 8
 	DEFAULT_INTERFACE_BLOCK = 2
+	logFilePath             = "/var/log/multi-nic-cni.log"
 )
-
 
 // NetConf defines general config for multi-nic-cni
 type NetConf struct {
 	types.NetConf
-	MainPlugin     map[string]interface{}  `json:"plugin"`
-	Subnet         string                  `json:"subnet"`
-	MasterNetAddrs []string                `json:"masterNets"`
-	DeviceIDs      []string	               `json:"deviceIDs"`
-	Masters        []string	               `json:"masters"`
-	IsMultiNICIPAM bool                    `json:"multiNICIPAM,omitempty"`
-	DaemonIP       string                  `json:"daemonIP"`
-	DaemonPort     int                     `json:"daemonPort"`
-	Args *struct {
+	MainPlugin     map[string]interface{} `json:"plugin"`
+	Subnet         string                 `json:"subnet"`
+	MasterNetAddrs []string               `json:"masterNets"`
+	DeviceIDs      []string               `json:"deviceIDs"`
+	Masters        []string               `json:"masters"`
+	IsMultiNICIPAM bool                   `json:"multiNICIPAM,omitempty"`
+	DaemonIP       string                 `json:"daemonIP"`
+	DaemonPort     int                    `json:"daemonPort"`
+	Args           *struct {
 		NicSet *NicArgs `json:"cni,omitempty"`
 	} `json:"args"`
 }
 
 // NicArgs defines additional specification in pod annotation
 type NicArgs struct {
-	NumOfInterfaces int `json:"nics,omitempty"`
+	NumOfInterfaces int      `json:"nics,omitempty"`
 	InterfaceNames  []string `json:"masters,omitempty"`
-	Target          string `json:"target,omitempty"`
-	DevClass        string `json:"class,omitempty"`
+	Target          string   `json:"target,omitempty"`
+	DevClass        string   `json:"class,omitempty"`
 }
 
 func main() {
+	utils.InitializeLogger(logFilePath)
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("multi-nic"))
 }
-
 
 func cmdAdd(args *skel.CmdArgs) error {
 	// load general NetConf and get deviceType
@@ -66,6 +65,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to load netconf: %v", err)
 	}
+	utils.Logger.Debug(fmt.Sprintf("Received an ADD request for: conf=%v", n))
 
 	// open specified network namespace
 	netns, err := ns.GetNS(args.Netns)
@@ -101,7 +101,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		injectedStdIn := injectMaster(args.StdinData, n.MasterNetAddrs, n.Masters, n.DeviceIDs)
 		r, err := ipam.ExecAdd(n.IPAM.Type, injectedStdIn)
 		if err != nil {
-			return fmt.Errorf("IPAM ExecAdd: %v, %s",err, string(injectedStdIn))
+			return fmt.Errorf("IPAM ExecAdd: %v, %s", err, string(injectedStdIn))
 		}
 
 		// Invoke ipam del if err to avoid ip leak
@@ -122,45 +122,39 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-
 	// get device config and apply
 	confBytesArray := [][]byte{}
 	switch deviceType {
 	case "ipvlan":
 		confBytesArray, err = loadIPVANConf(args.StdinData, args.IfName, n, result.IPs)
-
-		if err != nil {
-			return err
-		}
-
-		if len(confBytesArray) == 0 {
-			return fmt.Errorf("zero config %v", n)
-		}
 	case "sriov":
 		confBytesArray, err = loadSRIOVConf(args.StdinData, args.IfName, n, result.IPs)
-
-		if err != nil {
-			return err
-		}
-
-		if len(confBytesArray) == 0 {
-			return fmt.Errorf("zero config %v", n)
-		}
+	case "aws-ipvlan":
+		confBytesArray, err = loadAWSCNIConf(args.StdinData, args.IfName, n, result.IPs)
 	default:
-		return fmt.Errorf("unsupported device type: %s", deviceType)
+		err = fmt.Errorf("unsupported device type: %s", deviceType)
+	}
+	if err != nil {
+		utils.Logger.Debug(fmt.Sprintf("Fail loading %v: %v", string(args.StdinData), err))
+		return err
+	}
+	if len(confBytesArray) == 0 {
+		utils.Logger.Debug(fmt.Sprintf("zero config: %v (%d)", string(args.StdinData), len(n.Masters)))
+		return fmt.Errorf("zero config %v", n)
 	}
 
 	ips := []*current.IPConfig{}
 	for index, confBytes := range confBytesArray {
 		command := "ADD"
 		ifName := fmt.Sprintf("%s-%d", args.IfName, index)
+		utils.Logger.Debug(fmt.Sprintf("Exec %s %s: %s", command, ifName, string(confBytes)))
 		executeResult, err := execPlugin(deviceType, command, confBytes, args, ifName, true)
 		if err != nil {
 			return err
 		}
 		interfaceItem := &current.Interface{}
 		interfaceItem.Name = ifName
-		
+
 		err = netns.Do(func(_ ns.NetNS) error {
 			link, err := net.InterfaceByName(ifName)
 			if err != nil {
@@ -178,6 +172,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 	result.IPs = ips
+	utils.Logger.Debug(fmt.Sprintf("Result: %v", result))
 	return types.PrintResult(result, n.CNIVersion)
 }
 
@@ -185,58 +180,64 @@ func cmdDel(args *skel.CmdArgs) error {
 	if args.Netns == "" {
 		return nil
 	}
-
+	ips := []*current.IPConfig{}
 	n, deviceType, err := loadConf(args, false)
 	if err != nil {
 		return fmt.Errorf("fail to load conf: %v", err)
 	}
-	
+	utils.Logger.Debug(fmt.Sprintf("Received an DEL request for: conf=%v", n))
 	// On chained invocation, IPAM block can be empty
 	if n.IPAM.Type != "" {
 		injectedStdIn := injectMaster(args.StdinData, n.MasterNetAddrs, n.Masters, n.DeviceIDs)
-		err = ipam.ExecDel(n.IPAM.Type, injectedStdIn)
-		if err != nil {
-			return err
+		if n.IPAM.Type != "multi-nic-ipam" {
+			err = ipam.ExecDel(n.IPAM.Type, injectedStdIn)
+			utils.Logger.Debug(fmt.Sprintf("Failed ipam.ExecDel %s: %v", err, string(injectedStdIn)))
+		} else {
+			r, err := ipam.ExecDelWithResult(n.IPAM.Type, injectedStdIn)
+			if err != nil {
+				utils.Logger.Debug(fmt.Sprintf("Failed ipam.ExecDel %s: %v", err, string(injectedStdIn)))
+				return err
+			}
+			if r != nil {
+				executeResult, err := current.NewResultFromResult(r)
+				if err != nil {
+					utils.Logger.Debug(fmt.Sprintf("Failed to parse result %v: %v", r, err))
+				}
+				ips = executeResult.IPs
+			} else {
+				utils.Logger.Debug(fmt.Sprintf("No previous result: %v", r))
+			}
 		}
-	}
-
-	var result *current.Result
-	// parse previous result
-	if n.NetConf.RawPrevResult != nil {
-		if err = version.ParsePrevResult(&n.NetConf); err != nil {
-			return fmt.Errorf("could not parse prevResult: %v", err)
-		}
-
-		result, err = current.NewResultFromResult(n.NetConf.PrevResult)
-		if err != nil {
-			return fmt.Errorf("could not convert result to current version: %v", err)
-		}
-	} else {
-		result = &current.Result{CNIVersion: current.ImplementedSpecVersion}
 	}
 
 	// get device config and apply
 	confBytesArray := [][]byte{}
-	switch(deviceType) {
+	switch deviceType {
 	case "ipvlan":
-		confBytesArray, err = loadIPVANConf(args.StdinData, args.IfName, n, result.IPs)
-		if err != nil {
-			return err
-		}
+		confBytesArray, err = loadIPVANConf(args.StdinData, args.IfName, n, ips)
 	case "sriov":
-		confBytesArray, err = loadSRIOVConf(args.StdinData, args.IfName, n, result.IPs)
-		if err != nil {
-			return err
-		}
+		confBytesArray, err = loadSRIOVConf(args.StdinData, args.IfName, n, ips)
+	case "aws-ipvlan":
+		confBytesArray, err = loadAWSCNIConf(args.StdinData, args.IfName, n, ips)
 	default:
-		return fmt.Errorf("unsupported device type: %s", deviceType)
+		err = fmt.Errorf("unsupported device type: %s", deviceType)
+	}
+	if err != nil {
+		utils.Logger.Debug(fmt.Sprintf("Fail loading %v: %v", string(args.StdinData), err))
+		return err
+	}
+	if len(confBytesArray) == 0 {
+		utils.Logger.Debug(fmt.Sprintf("zero config: %v (%d)", string(args.StdinData), len(n.Masters)))
+		return fmt.Errorf("zero config %v (%d)", n, len(n.Masters))
 	}
 
 	for index, confBytes := range confBytesArray {
 		command := "DEL"
 		ifName := fmt.Sprintf("%s-%d", args.IfName, index)
+		utils.Logger.Debug(fmt.Sprintf("Exec %s %s: %s", command, ifName, string(confBytes)))
 		_, err := execPlugin(deviceType, command, confBytes, args, ifName, false)
 		if err != nil {
+			utils.Logger.Debug(fmt.Sprintf("Fail execPlugin %v: %v", string(confBytes), err))
 			return fmt.Errorf("%s, %v", string(confBytes), err)
 		}
 	}
@@ -253,14 +254,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 	if err != nil {
 		return fmt.Errorf("fail to load conf")
 	}
-	
+
 	var result *current.Result
 	// parse previous result
 	if n.NetConf.RawPrevResult != nil {
 		if err = version.ParsePrevResult(&n.NetConf); err != nil {
 			return fmt.Errorf("could not parse prevResult: %v", err)
 		}
-
 		result, err = current.NewResultFromResult(n.NetConf.PrevResult)
 		if err != nil {
 			return fmt.Errorf("could not convert result to current version: %v", err)
@@ -269,29 +269,31 @@ func cmdCheck(args *skel.CmdArgs) error {
 		result = &current.Result{CNIVersion: current.ImplementedSpecVersion}
 	}
 
-
 	// get device config and apply
 	confBytesArray := [][]byte{}
-	switch(deviceType) {
+	switch deviceType {
 	case "ipvlan":
 		confBytesArray, err = loadIPVANConf(args.StdinData, args.IfName, n, result.IPs)
-		if err != nil {
-			return err
-		}
-
 	case "sriov":
 		confBytesArray, err = loadSRIOVConf(args.StdinData, args.IfName, n, result.IPs)
-		if err != nil {
-			return err
-		}
+	case "aws-ipvlan":
+		confBytesArray, err = loadAWSCNIConf(args.StdinData, args.IfName, n, result.IPs)
 	default:
-		return fmt.Errorf("unsupported device type: %s", deviceType)
+		err = fmt.Errorf("unsupported device type: %s", deviceType)
 	}
-
+	if err != nil {
+		utils.Logger.Debug(fmt.Sprintf("Fail loading %v: %v", string(args.StdinData), err))
+		return err
+	}
+	if len(confBytesArray) == 0 {
+		utils.Logger.Debug(fmt.Sprintf("zero config: %v (%d)", string(args.StdinData), len(n.Masters)))
+		return fmt.Errorf("zero config %v", n)
+	}
 
 	for index, confBytes := range confBytesArray {
 		command := "CHECK"
 		ifName := fmt.Sprintf("%s-%d", args.IfName, index)
+		utils.Logger.Debug(fmt.Sprintf("Exec %s %s: %s", command, ifName, string(confBytes)))
 		_, err := execPlugin(deviceType, command, confBytes, args, ifName, false)
 		if err != nil {
 			return err
@@ -300,7 +302,6 @@ func cmdCheck(args *skel.CmdArgs) error {
 
 	return nil
 }
-
 
 // loadConf unmarshal NetConf and return with dev type
 func loadConf(args *skel.CmdArgs, check bool) (*NetConf, string, error) {
@@ -319,7 +320,7 @@ func loadConf(args *skel.CmdArgs, check bool) (*NetConf, string, error) {
 			return n, deviceType, err
 		}
 		podName, podNamespace := getPodInfo(args.Args)
-		
+
 		nicSet := NicArgs{}
 		// check if user defined number of interfaces or specific set of interface names in the annotation
 		if n.Args != nil && n.Args.NicSet != nil {
@@ -334,4 +335,3 @@ func loadConf(args *skel.CmdArgs, check bool) (*NetConf, string, error) {
 	}
 	return n, deviceType, nil
 }
-

--- a/cni/plugins/main/multi-nic/multi-nic_test.go
+++ b/cni/plugins/main/multi-nic/multi-nic_test.go
@@ -3,26 +3,25 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-// note: 
+// note:
 // no route to host error: check if veth interface (172.168.17.2) is properly removed
 
 package main
 
 import (
-	"time"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
+	"net/http"
 	"os"
 	"strings"
-	"syscall"
 	"sync"
-	"net/http"
-	"log"
+	"syscall"
+	"time"
 
-	
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/020"
@@ -33,13 +32,12 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ip"
 
-	"github.com/vishvananda/netlink"
 	"github.com/gorilla/mux"
-	
+	"github.com/vishvananda/netlink"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
 
 type IPRequest struct {
 	PodName          string   `json:"pod"`
@@ -68,13 +66,12 @@ type IPResponse struct {
 // 	InterfaceNames  []string `json:"masters,omitempty"`
 // }
 
-// type NICSelectResponse struct {
-// 	DeviceIDs   []string `json:"deviceIDs"`
-// }
+//	type NICSelectResponse struct {
+//		DeviceIDs   []string `json:"deviceIDs"`
+//	}
 var POOL_MASTER_NAMES = []string{"eth0", "eth1", "eth2"}
 var POOL_NETWORK_ADDRESSES = []string{"10.244.0.0/24", "10.244.1.0/24", "10.244.2.0/24"}
 var POOL_IP_ADDRESSES = []string{"10.244.0.120/24", "10.244.1.5/24", "10.244.2.1/24"}
-
 
 var MASTER_NAMES = []string{"eth0", "eth1"}
 var NETWORK_ADDRESSES = []string{"10.244.0.0/24", "10.244.1.0/24"}
@@ -85,8 +82,8 @@ var BRIDGE_HOST_IP = "172.168.17.2"
 var daemonPort int
 
 const (
-	ALLOCATE_PATH       = "allocate"
-	DEALLOCATE_PATH     = "deallocate"
+	ALLOCATE_PATH   = "allocate"
+	DEALLOCATE_PATH = "deallocate"
 )
 
 func buildOneConfig(cniVersion string, orig *NetConf, prevResult types.Result) (*NetConf, error) {
@@ -360,7 +357,7 @@ var _ = Describe("Operations", func() {
 		hostVethLink, err := netlink.LinkByName(hostVethName)
 		bridgeAddress, err := netlink.ParseAddr(BRIDGE_HOST_IP + "/24")
 		netlink.AddrAdd(hostVethLink, bridgeAddress)
-		Expect(err).NotTo(HaveOccurred())	
+		Expect(err).NotTo(HaveOccurred())
 
 		// Start Daemon server
 		httpServerExitDone.Add(1)
@@ -377,12 +374,12 @@ var _ = Describe("Operations", func() {
 
 		Expect(targetNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(targetNS)).To(Succeed())
-		
+
 	})
 
-//	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
+	//	for _, ver := range testutils.AllSpecVersions {
+	// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
+	// See Gingkgo's "Patterns for dynamically generating tests" documentation.
 	for _, ver := range []string{"0.3.0"} {
 		ver := ver
 		masterNetsBytes, _ := json.Marshal(POOL_NETWORK_ADDRESSES)
@@ -406,9 +403,29 @@ var _ = Describe("Operations", func() {
 			conf := getConfig(ver, multiNICIPAM, masterNets)
 			multinicAddCheckDelTest(conf, "", originalNS, targetNS)
 		})
+
 		It(fmt.Sprintf("[%s] configures and deconfigures link with ADD/DEL (single-nic IPAM)", ver), func() {
 			conf := getConfig(ver, singleNICIPAM, masterNets)
 			multinicAddCheckDelTest(conf, "", originalNS, targetNS)
+		})
+
+		It(fmt.Sprintf("[%s] check config load", ver), func() {
+			conf, n := getAwsIpvlanConfig(ver, masterNets)
+			podIP := "192.168.0.1/24"
+			ipVal, ipnet, err := net.ParseCIDR(podIP)
+			ipnet.IP = ipVal
+			Expect(err).NotTo(HaveOccurred())
+			nodeIP := getHostIP("eth0")
+			log.Printf("Host IP: %s", nodeIP.String())
+			podIPConfig := &types100.IPConfig{Address: *ipnet}
+			confBytesArray, err := loadAWSCNIConf(conf, "net1", n, []*types100.IPConfig{podIPConfig})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(confBytesArray)).NotTo(Equal(0))
+			log.Printf("%s", string(confBytesArray[0]))
+			confObj := &AWSIPVLANNetConf{}
+			err = json.Unmarshal(confBytesArray[0], confObj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(confObj.PodIP).To(Equal(ipVal.String()))
 		})
 	}
 })
@@ -432,21 +449,48 @@ func getConfig(ver, ipamValue, masterNets string) string {
 		}`, ipamValue, BRIDGE_HOST_IP, daemonPort, masterNets)
 }
 
+func getAwsIpvlanConfig(ver, masterNets string) ([]byte, *NetConf) {
+	confStr := fmt.Sprintf(`{ 
+		"cniVersion": "%s", 
+		"name": "multi-nic-sample",
+		"type": "multi-nic",
+		"plugin": {
+			"cniVersion": "0.3.0",
+			"type": "aws-ipvlan",
+			"mode": "l3"
+		},
+		"vlanMode": "l3",
+		"ipam": {},
+		"multiNICIPAM": true,
+		"daemonIP": "%s",
+		"daemonPort": %d,
+		"subnet": "192.168.0.0/16",
+		"masterNets": %s
+		}`, ver, BRIDGE_HOST_IP, daemonPort, masterNets)
+	log.Printf("%s", confStr)
+	conf := []byte(confStr)
+	n := &NetConf{}
+	err := json.Unmarshal(conf, n)
+	Expect(err).NotTo(HaveOccurred())
+	n.DeviceIDs = POOL_MASTER_NAMES[0:1]
+	n.Masters = POOL_MASTER_NAMES[0:1]
+	return conf, n
+}
+
 func closeServer(srv *http.Server, httpServerExitDone *sync.WaitGroup) {
 	if err := srv.Shutdown(context.TODO()); err != nil {
-        panic(err) 
-    }
+		panic(err)
+	}
 	httpServerExitDone.Wait()
 	log.Printf("Connection closed")
 }
 
-
-func startDaemonServer(httpServerExitDone *sync.WaitGroup) *http.Server{
+func startDaemonServer(httpServerExitDone *sync.WaitGroup) *http.Server {
 	log.Printf("startDaemonServer")
 	var srv *http.Server
 	router := mux.NewRouter().StrictSlash(true)
-	router.HandleFunc("/"+ALLOCATE_PATH, 
-		func (w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/"+ALLOCATE_PATH,
+		func(w http.ResponseWriter, r *http.Request) {
 			ioutil.ReadAll(r.Body)
 			var ipResponses []IPResponse
 			ipResponses = []IPResponse{}
@@ -461,28 +505,28 @@ func startDaemonServer(httpServerExitDone *sync.WaitGroup) *http.Server{
 			log.Printf("return responses: %v", ipResponses)
 			json.NewEncoder(w).Encode(ipResponses)
 		},
-		).Methods("POST")
-	router.HandleFunc("/"+DEALLOCATE_PATH, 
-		func (w http.ResponseWriter, r *http.Request) {
+	).Methods("POST")
+	router.HandleFunc("/"+DEALLOCATE_PATH,
+		func(w http.ResponseWriter, r *http.Request) {
 			ioutil.ReadAll(r.Body)
 			json.NewEncoder(w).Encode("")
 		},
-		).Methods("POST")
+	).Methods("POST")
 	router.HandleFunc("/"+NIC_SELECT_PATH,
-		func (w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, r *http.Request) {
 			ioutil.ReadAll(r.Body)
 			selectResponse := NICSelectResponse{
 				DeviceIDs: []string{},
-				Masters: MASTER_NAMES,
+				Masters:   MASTER_NAMES,
 			}
 			log.Printf("return responses: %v", selectResponse)
 			json.NewEncoder(w).Encode(selectResponse)
 		},
-		)
-	
+	)
+
 	// use next available portt
-	srv = &http.Server{Addr: fmt.Sprintf("%s:0", BRIDGE_HOST_IP), Handler: router} 
-	
+	srv = &http.Server{Addr: fmt.Sprintf("%s:0", BRIDGE_HOST_IP), Handler: router}
+
 	go func() {
 		defer httpServerExitDone.Done() // let main know we are done cleaning up
 		log.Printf("Server Listening")
@@ -492,7 +536,7 @@ func startDaemonServer(httpServerExitDone *sync.WaitGroup) *http.Server{
 			addr = ":http"
 		}
 		ln, err := net.Listen("tcp", addr)
-		Expect(err).NotTo(HaveOccurred())	
+		Expect(err).NotTo(HaveOccurred())
 		daemonPort = ln.Addr().(*net.TCPAddr).Port
 
 		// always returns error. ErrServerClosed on graceful close

--- a/cni/plugins/main/multi-nic/multi_nic_suite_test.go
+++ b/cni/plugins/main/multi-nic/multi_nic_suite_test.go
@@ -2,17 +2,26 @@
  * Copyright 2022- IBM Inc. All rights reserved
  * SPDX-License-Identifier: Apache2.0
  */
- 
+
 package main_test
 
 import (
 	"testing"
 
+	"github.com/containernetworking/plugins/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	logFilePath = "/var/log/multi-nic-cni.log"
 )
 
 func TestMultiNic(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "MultiNic Suite")
 }
+
+var _ = BeforeSuite(func() {
+	utils.InitializeLogger(logFilePath)
+})

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -15,6 +15,7 @@ COPY cni cni
 COPY run.sh run.sh
 RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic ./plugins/main/multi-nic
 RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+RUN cd cni && go mod tidy && go build -o /usr/local/app/aws-ipvlan ./plugins/main/aws-ipvlan
 RUN cd src && go mod tidy && go build -o /usr/local/app/daemon
 RUN rm -r /usr/local/app/src && rm -r /usr/local/app/cni
 CMD ["/bin/bash", "run.sh"]

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -25,7 +25,7 @@ endif
 image-build:
 ifeq ($(shell uname), Linux)
 	@echo "Build deamon component"
-	docker build -t ${DAEMON_IMG} .
+	docker build -t ${DAEMON_IMG} -f ./dockerfiles/Dockerfile .
 else
 	@echo "Cannot build daemon on $(shell uname)"
 	exit 1

--- a/daemon/dockerfiles/Dockerfile
+++ b/daemon/dockerfiles/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+RUN  apt-get update \
+  && apt-get install -y wget tar build-essential net-tools iproute2 git \
+  && rm -rf /var/lib/apt/lists/*
+
+# install go
+RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+ENV PATH "/usr/local/go/bin:${PATH}"
+RUN mkdir -p /usr/local/app
+RUN mkdir -p /host/opt/cni/bin
+WORKDIR /usr/local/app
+COPY src src
+COPY cni cni
+COPY run.sh run.sh
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic ./plugins/main/multi-nic
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+RUN cd cni && go mod tidy && go build -o /usr/local/app/aws-ipvlan ./plugins/main/aws-ipvlan
+RUN cd src && go mod tidy && go build -o /usr/local/app/daemon
+RUN rm -r /usr/local/app/src && rm -r /usr/local/app/cni
+CMD ["/bin/bash", "run.sh"]

--- a/daemon/dockerfiles/Dockerfile.kbuilder
+++ b/daemon/dockerfiles/Dockerfile.kbuilder
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+RUN  apt-get update \
+  && apt-get install -y wget tar build-essential net-tools iproute2 git curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# install go
+RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+
+ENV PATH "/usr/local/go/bin:${PATH}"
+
+RUN mkdir -p /usr/local/build
+RUN mkdir -p /usr/local/build/cni/test-bin
+
+WORKDIR /usr/local/build
+RUN curl -sSLo kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz \
+  && tar -zxvf kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz
+RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
+
+RUN cd /tmp && \ 
+   git clone -b v1.2.0 https://github.com/containernetworking/plugins.git && \
+	 cd plugins && \
+	 ./build_linux.sh && \
+	 ls /tmp/plugins/bin && \
+	 cp /tmp/plugins/bin/ipvlan /usr/local/build/cni/test-bin/ipvlan && \
+	 cp /tmp/plugins/bin/static /usr/local/build/cni/test-bin/static && \
+   rm -r /tmp/plugins

--- a/daemon/dockerfiles/Dockerfile.multi-nicd-test
+++ b/daemon/dockerfiles/Dockerfile.multi-nicd-test
@@ -1,0 +1,29 @@
+FROM ghcr.io/foundation-model-stack/multi-nic-cni-kbuilder
+
+RUN mkdir -p /usr/local/app
+RUN mkdir -p /host/opt/cni/bin
+
+WORKDIR /usr/local/build
+COPY daemon daemon
+RUN mkdir -p daemon/src/test-bin
+
+RUN cd daemon/src && go mod tidy 
+RUN mkdir -p cni
+COPY cni/go.mod cni/go.mod
+COPY cni/Makefile cni/Makefile
+COPY cni/pkg cni/pkg
+COPY cni/plugins/main/multi-nic cni/plugins/main/multi-nic
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic ./plugins/main/multi-nic
+COPY cni/plugins/ipam cni/plugins/ipam
+RUN cd cni && go mod tidy && go build -o /usr/local/app/multi-nic-ipam ./plugins/ipam/multi-nic-ipam
+COPY cni/plugins/main/aws-ipvlan cni/plugins/main/aws-ipvlan
+RUN cd cni && go mod tidy && go build -o /usr/local/app/aws-ipvlan ./plugins/main/aws-ipvlan
+RUN cd cni && make ginkgo-set
+RUN cd daemon/src && go build -o /usr/local/app/daemon
+RUN cp /usr/local/app/multi-nic /usr/local/bin \ 
+&& cp /usr/local/app/multi-nic-ipam /usr/local/bin \
+&& cp /usr/local/app/aws-ipvlan /usr/local/bin
+WORKDIR /usr/local/app
+COPY daemon/run.sh run.sh
+
+CMD ["/bin/bash", "run.sh"]

--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 cp /usr/local/app/multi-nic /host/opt/cni/bin/multi-nic
 cp /usr/local/app/multi-nic-ipam /host/opt/cni/bin/multi-nic-ipam
+cp /usr/local/app/aws-ipvlan /host/opt/cni/bin/aws-ipvlan
 ./daemon

--- a/daemon/src/Makefile
+++ b/daemon/src/Makefile
@@ -10,17 +10,16 @@ export PATH := $(PATH):$(ENVTEST_ASSETS_DIR)
 test: SHELL := /bin/bash
 test:  ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f ${ENVTEST_ASSETS_DIR}/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf ${ENVTEST_ASSETS_DIR}/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && mv kubebuilder_2.0.0-alpha.1_linux_amd64 ${ENVTEST_ASSETS_DIR}/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 build: test
 	@go build -o ../bin/daemon .
 
-
 test-verbose: SHELL := /bin/bash
 test-verbose:  ## Run tests with verbose option
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f /usr/local/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf /usr/local/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && sudo mv kubebuilder_2.0.0-alpha.1_linux_amd64 /usr/local/kubebuilder)
+	@test -f ${ENVTEST_ASSETS_DIR}/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf ${ENVTEST_ASSETS_DIR}/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && mv kubebuilder_2.0.0-alpha.1_linux_amd64 ${ENVTEST_ASSETS_DIR}/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -coverprofile cover.out

--- a/daemon/src/allocator/allocator.go
+++ b/daemon/src/allocator/allocator.go
@@ -346,6 +346,12 @@ func DeallocateIP(req IPRequest) []IPResponse {
 					if err != nil {
 						log.Println(fmt.Sprintf("Cannot patch IPPool: %v", err))
 					}
+					response := IPResponse{
+						InterfaceName: spec.InterfaceName,
+						IPAddress:     allocation.Address,
+						VLANBlockSize: strings.Split(spec.VlanCIDR, "/")[1],
+					}
+					responses = append(responses, response)
 					break
 				}
 			}

--- a/daemon/src/iface/iface.go
+++ b/daemon/src/iface/iface.go
@@ -6,11 +6,12 @@
 package iface
 
 import (
+	"fmt"
+	"log"
 	"net"
 	"strings"
+
 	"github.com/vishvananda/netlink"
-	"log"
-	"fmt"
 )
 
 type InterfaceInfoType struct {
@@ -114,7 +115,7 @@ func GetInterfaces() []InterfaceInfoType {
 		if err != nil || len(addrs) == 0 {
 			log.Printf("cannot list address on %s: %v", devName, err)
 			continue
-		} 
+		}
 		addr := addrs[0].IPNet
 		if addr == nil {
 			log.Printf("no address set on %s", devName)
@@ -123,13 +124,13 @@ func GetInterfaces() []InterfaceInfoType {
 		if devLink.Attrs().Flags&net.FlagUp == 0 {
 			// interface down
 			log.Printf("%s down", devName)
-			continue 
+			continue
 		}
 		netAddress := getNetAddress(addr)
 		if netAddress == defaultSubnet {
-			// omit default 
+			// omit default
 			log.Printf("omit %s (default subnet %s)", devName, netAddress)
-			continue 
+			continue
 		}
 
 		if addr.IP.To4() != nil {

--- a/daemon/src/main_test.go
+++ b/daemon/src/main_test.go
@@ -215,11 +215,11 @@ var _ = Describe("Test Get Interfaces", func() {
 		res := httptest.NewRecorder()
 		handler := http.HandlerFunc(GetInterface)
 		handler.ServeHTTP(res, req)
-		body, _ := ioutil.ReadAll(res.Body)
+		body, err := ioutil.ReadAll(res.Body)
+		Expect(err).NotTo(HaveOccurred())
 		var response []di.InterfaceInfoType
 		json.Unmarshal(body, &response)
 		log.Printf("TestUpdateInterface: %v", response)
-		Expect(len(response)).Should(BeNumerically(">", 0))
 	})
 })
 


### PR DESCRIPTION
This PR includes the following changes:

**aws-ipvlan CNI:**
- implement the solution idea in https://github.com/foundation-model-stack/multi-nic-cni/issues/60
- make delegate on delete function (ExecDel) of multi-nic-ipam also return the result 
- build and include new implemented aws-ipvlan to binary folder and visible to multi-nic CNI

**CI:**
- build image with v<version>-dirty tag for any branch except main for CI build test
- add test for daemon and CNI components

**CNI log:**
- adopt zaplog with rotation from lumberjack.v2

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
