### PR TITLE
Add aws-ipvlan plugin to controller

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -2,8 +2,6 @@ name: Build and push controller and its bundle image
 
 on:
   push:
-    branches:
-      - main
     paths:
       - controllers/**
       - compute/**
@@ -47,14 +45,17 @@ jobs:
         run: make bundle
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
+        if: ${{ github.ref != 'refs/heads/main' }}
       - name: Login to Docker
         uses: docker/login-action@v1
+        if: ${{ github.ref != 'refs/heads/main' }}
         with:
           registry: ghcr.io
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push bundle
         uses: docker/build-push-action@v2
+        if: ${{ github.ref != 'refs/heads/main' }}
         with:
           context: .
           push: true
@@ -85,6 +86,7 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push controller
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -93,4 +95,14 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:v${{ env.VERSION }}
+          file: ./Dockerfile
+      - name: Build and push controller (dirty)
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
+            ${{ env.IMAGE_NAME }}:v${{ env.VERSION }}-dirty
           file: ./Dockerfile

--- a/config/samples/net_v1_awsipvlan.yaml
+++ b/config/samples/net_v1_awsipvlan.yaml
@@ -1,0 +1,20 @@
+apiVersion: multinic.fms.io/v1
+kind: MultiNicNetwork
+metadata:
+  name: multinic-aws-ipvlan
+spec:
+  ipam: |
+    {
+      "type": "multi-nic-ipam",
+      "hostBlock": 8, 
+      "interfaceBlock": 2,
+      "vlanMode": "l2"
+    }
+  multiNICIPAM: true
+  plugin:
+    cniVersion: "0.3.0"
+    type: aws-ipvlan
+    args: 
+      mode: l2
+  namespaces:
+  - default

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -230,8 +230,12 @@ func (r *ConfigReconciler) newCNIDaemonSet(client *kubernetes.Clientset, name st
 	}
 
 	// prepare secret
-	secret := corev1.LocalObjectReference{
-		Name: daemonSpec.ImagePullSecret,
+	secrets := []corev1.LocalObjectReference{}
+	if daemonSpec.ImagePullSecret == "" {
+		secret := corev1.LocalObjectReference{
+			Name: daemonSpec.ImagePullSecret,
+		}
+		secrets = append(secrets, secret)
 	}
 	// prepare container
 	container := corev1.Container{
@@ -267,10 +271,8 @@ func (r *ConfigReconciler) newCNIDaemonSet(client *kubernetes.Clientset, name st
 					Containers: []corev1.Container{
 						container,
 					},
-					Volumes: volumes,
-					ImagePullSecrets: []corev1.LocalObjectReference{
-						secret,
-					},
+					Volumes:          volumes,
+					ImagePullSecrets: secrets,
 				},
 			},
 		},

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -135,4 +135,19 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		contains, index = multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
 		Expect(contains).To(Equal(false))
 	})
+
+	It("Empty subnet", func() {
+		emptySubnetMultinicnetwork := getMultiNicCNINetwork("empty-ipam", cniVersion, cniType, cniArgs)
+		emptySubnetMultinicnetwork.Spec.Subnet = ""
+		ipamConfig, err := multinicnetworkReconciler.getIPAMConfig(emptySubnetMultinicnetwork)
+		ipamConfig.InterfaceBlock = 0
+		ipamConfig.HostBlock = 4
+		Expect(err).NotTo(HaveOccurred())
+		cidrSpec, err := multinicnetworkReconciler.CIDRHandler.generateCIDRFromHostSubnet(*ipamConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(cidrSpec.CIDRs)).To(Equal(len(interfaceNames)))
+		fmt.Println(cidrSpec)
+		hostIPs := multinicnetworkReconciler.CIDRHandler.getHostAddressesToExclude()
+		Expect(len(hostIPs)).To(BeEquivalentTo(len(interfaceNames) * multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.GetSize()))
+	})
 })

--- a/controllers/multinicnetwork_controller.go
+++ b/controllers/multinicnetwork_controller.go
@@ -54,9 +54,16 @@ func GetPluginMap(config *rest.Config, logger logr.Logger) map[string]*PluginInt
 		Log: logger,
 	}
 	pluginMap[plugin.SRIOV_TYPE] = new(PluginInterface)
-	sriovPlugin := &plugin.SriovPlugin{Log: logger}
+	sriovPlugin := &plugin.SriovPlugin{
+		Log: logger,
+	}
 	sriovPlugin.Init(config)
 	*pluginMap[plugin.SRIOV_TYPE] = sriovPlugin
+	pluginMap[plugin.AWS_IPVLAN_TYPE] = new(PluginInterface)
+	awsVpcCNIPlugin := &plugin.AwsVpcCNIPlugin{
+		Log: logger,
+	}
+	*pluginMap[plugin.AWS_IPVLAN_TYPE] = awsVpcCNIPlugin
 	return pluginMap
 }
 

--- a/plugin/awsipvlan.go
+++ b/plugin/awsipvlan.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package plugin
+
+import (
+	"encoding/json"
+
+	"github.com/containernetworking/cni/pkg/types"
+	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	AWS_IPVLAN_TYPE = "aws-ipvlan"
+)
+
+type AwsVpcCNIPlugin struct {
+	Log logr.Logger
+}
+
+type AWSIPVLANNetConf struct {
+	types.NetConf
+	PrimaryIP map[string]interface{} `json:"primaryIP"`
+	PodIP     string                 `json:"podIP"`
+	Master    string                 `json:"master"`
+	Mode      string                 `json:"mode"`
+	MTU       int                    `json:"mtu"`
+}
+
+func (p *AwsVpcCNIPlugin) Init(config *rest.Config, logger logr.Logger) error {
+	return nil
+}
+
+func (p *AwsVpcCNIPlugin) GetConfig(net multinicv1.MultiNicNetwork, hifList map[string]multinicv1.HostInterface) (string, map[string]string, error) {
+	spec := net.Spec.MainPlugin
+	args := spec.CNIArgs
+	conf := &AWSIPVLANNetConf{}
+	argBytes, _ := json.Marshal(args)
+	json.Unmarshal(argBytes, conf)
+	conf.CNIVersion = net.Spec.MainPlugin.CNIVersion
+	conf.Type = AWS_IPVLAN_TYPE
+	val, err := getInt(args, "mtu")
+	if err == nil {
+		conf.MTU = val
+	}
+	confBytes, err := json.Marshal(conf)
+	if err != nil {
+		return "", make(map[string]string), err
+	}
+	return string(confBytes), make(map[string]string), nil
+}
+
+func (p *AwsVpcCNIPlugin) CleanUp(net multinicv1.MultiNicNetwork) error {
+	return nil
+}


### PR DESCRIPTION
Corresponding to https://github.com/foundation-model-stack/multi-nic-cni/issues/60, https://github.com/foundation-model-stack/multi-nic-cni/pull/61, this PR makes support for aws-ipvlan with the following changes.

- Generate CIDR based on Host subnet instead of pre-defined subnet
- Add awsipvlan plugin interface and add to pluginMap

Additionally, this PR also includes the following fixes and updates.
- build controller image with v-dirty tag for any branch except main for CI build test
- fix empty daemonSpec.ImagePullSecret case

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>