### PR TITLE
activate unit/integration test for all branches based on path

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,14 +2,18 @@ name: e2e test
 
 on:
   pull_request:
-    branches:    
-      - controller
-      - main
+    paths:
+      - controllers/**
+      - compute/**
+      - plugin/**
+      - ./main.go
+      - ./go.mod
+      - config/**
+      - ./Dockerfile
+      - ./bundle.Dockerfile
+      - ./Makefile
+      - e2e-test/**
   push:
-    branches:
-      - main
-      - controller
-      - e2e-test
     paths:
       - controllers/**
       - compute/**

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -2,12 +2,23 @@ name: Perform unittest for controller
 
 on:
   pull_request:
-    branches:    
-    - controller
-    - main
+    paths:
+      - controllers/**
+      - compute/**
+      - plugin/**
+      - ./main.go
+      - ./go.mod
+      - ./bundle.Dockerfile
+      - ./Makefile
   push:
-    branches:
-    - controller
+    paths:
+      - controllers/**
+      - compute/**
+      - plugin/**
+      - ./main.go
+      - ./go.mod
+      - ./bundle.Dockerfile
+      - ./Makefile
 
 jobs:
 


### PR DESCRIPTION
This PR changes condition to activate unit test and integration test to all branches (checking only related path).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>