### PR TITLE
Fix test bug issue #52 #57

### DIFF
--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -42,6 +42,10 @@ func InitHostInterfaceCache(clientset *kubernetes.Clientset, hostInterfaceHandle
 	listObjects, err := hostInterfaceHandler.ListHostInterface()
 	if err == nil {
 		for name, instance := range listObjects {
+			if _, ok := instance.Labels[TestModelLabel]; ok {
+				// on test mode, no need to init
+				break
+			}
 			if _, foundErr := daemonCacheHandler.GetCache(name); foundErr != nil {
 				// not found, check whether node is still there.
 				if _, foundErr = clientset.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{}); foundErr != nil {

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -25,6 +25,7 @@ func updateCIDR(multinicnetwork *multinicv1.MultiNicNetwork, cidr multinicv1.CID
 	expectedPodCIDR := 0
 	if changed {
 		snapshot := multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.ListCache()
+		Expect(len(snapshot)).Should(BeNumerically(">", 0))
 		for _, hif := range snapshot {
 			for _, iface := range hif.Spec.Interfaces {
 				for _, masterAddresses := range networkAddresses {

--- a/controllers/multinicnetwork_controller.go
+++ b/controllers/multinicnetwork_controller.go
@@ -158,9 +158,11 @@ func (r *MultiNicNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		cidr, err := r.CIDRHandler.GetCache(multinicnetworkName)
 		if err == nil {
 			routeStatus = r.CIDRHandler.SyncCIDRRoute(cidr, false)
-			err := r.CIDRHandler.MultiNicNetworkHandler.SyncAllStatus(multinicnetworkName, cidr, routeStatus, daemonSize, infoAvailableSize, false)
+			netStatus, err := r.CIDRHandler.MultiNicNetworkHandler.SyncAllStatus(multinicnetworkName, cidr, routeStatus, daemonSize, infoAvailableSize, false)
 			if err != nil {
 				r.Log.V(2).Info(fmt.Sprintf("failed to update route status of %s: %v", multinicnetworkName, err))
+			} else if netStatus.CIDRProcessedHost != netStatus.InterfaceInfoAvailable {
+				r.CIDRHandler.UpdateCIDRs()
 			}
 			if routeStatus == multinicv1.RouteUnknown {
 				return ctrl.Result{RequeueAfter: ReconcileTime}, nil

--- a/controllers/route_handler.go
+++ b/controllers/route_handler.go
@@ -41,6 +41,12 @@ func (h *RouteHandler) AddRoutes(cidrSpec multinicv1.CIDRSpec, entries []multini
 
 // AddRoutesToHost add route to a specific host
 func (h *RouteHandler) AddRoutesToHost(cidrSpec multinicv1.CIDRSpec, hostName string, daemon DaemonPod, entries []multinicv1.CIDREntry, hostInterfaceInfoMap map[string]map[int]multinicv1.HostInterfaceInfo, forceDelete bool) (bool, bool) {
+	_, err := h.DaemonCacheHandler.GetCache(hostName)
+	if err != nil {
+		h.Log.V(6).Info(fmt.Sprintf("fail to apply L3config %s to %s: %v", cidrSpec.Config.Name, hostName, err))
+		// no change, connecion failed
+		return false, true
+	}
 	change := true
 	mainSrcHostIP := daemon.HostIP
 	routes := []HostRoute{}

--- a/controllers/synchronizer.go
+++ b/controllers/synchronizer.go
@@ -31,9 +31,11 @@ func RunPeriodicUpdate(ticker *time.Ticker, daemonWatcher *DaemonWatcher, cidrHa
 					for name, instanceSpec := range cidrSnapshot {
 						routeStatus := cidrHandler.SyncCIDRRoute(instanceSpec, false)
 						cidrHandler.CleanPendingIPPools(ippoolSnapshot, name, instanceSpec)
-						err := cidrHandler.MultiNicNetworkHandler.SyncAllStatus(name, instanceSpec, routeStatus, daemonSize, infoAvailableSize, false)
+						netStatus, err := cidrHandler.MultiNicNetworkHandler.SyncAllStatus(name, instanceSpec, routeStatus, daemonSize, infoAvailableSize, false)
 						if err != nil {
 							logger.V(2).Info(fmt.Sprintf("failed to update route status of %s: %v", name, err))
+						} else if netStatus.CIDRProcessedHost != netStatus.InterfaceInfoAvailable {
+							cidrHandler.UpdateCIDRs()
 						}
 					}
 				}

--- a/e2e-test/deploy/controller/deployment.yaml
+++ b/e2e-test/deploy/controller/deployment.yaml
@@ -1502,6 +1502,8 @@ spec:
         - --health-probe-bind-address=:8083
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect=false
+        - --zap-log-level=10
+        - --zap-stacktrace-level=error
         command:
         - /manager
         env:


### PR DESCRIPTION
This PR is to fix the randomly-occurred bug posted in https://github.com/foundation-model-stack/multi-nic-cni/issues/52 and https://github.com/foundation-model-stack/multi-nic-cni/issues/57 by the following changes.

**unit test fixes**
- prevent deleting HostInterface resource in unit test at function InitHostInterfaceCache when the real daemon pod does not exist

**scale test fixes**
- add missing HostInterface resource at InitHostInterfaceCache which might happen when the daemon pods created while controller not properly running (HostInterface is not created)
- at every sync, check progress status whether satisfied or not. If not, try updating CIDR. (operation issue)
- reconcile CIDR resource if cannot successfully update multinicnetwork status. (operation issue)
- skip handling routes when daemon has been already deleted. (performance issue)
- add script to reset the fake node when the stub pod is reset unexpectedly which causes fake node IP changes
- add script to detect hang state when waiting for n nodes become ready

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>