### PR TITLE
fix zero config load on delete and check

### DIFF
--- a/cni/plugins/main/multi-nic/ipvlan.go
+++ b/cni/plugins/main/multi-nic/ipvlan.go
@@ -2,14 +2,15 @@
  * Copyright 2022- IBM Inc. All rights reserved
  * SPDX-License-Identifier: Apache2.0
  */
- 
+
 package main
 
 import (
 	"encoding/json"
 	"fmt"
-	current "github.com/containernetworking/cni/pkg/types/100"
+
 	"github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
 )
 
 // IPVLANNetConfig defines ipvlan net config
@@ -18,14 +19,14 @@ import (
 // MTU    int    `json:"mtu"`
 type IPVLANNetConfig struct {
 	types.NetConf
-	MainPlugin             IPVLANTypeNetConf `json:"plugin"`
+	MainPlugin IPVLANTypeNetConf `json:"plugin"`
 }
 
 type IPVLANTypeNetConf struct {
 	types.NetConf
 	Master string `json:"master"`
 	Mode   string `json:"mode"`
-	MTU    int    `json:"mtu"`	
+	MTU    int    `json:"mtu"`
 }
 
 // loadIPVANConf unmarshal to IPVLANNetConfig and returns list of IPVLAN configs
@@ -46,7 +47,7 @@ func loadIPVANConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*current
 		}
 		if singleConfig.CNIVersion == "" {
 			singleConfig.CNIVersion = n.CNIVersion
-		} 
+		}
 		singleConfig.Name = fmt.Sprintf("%s-%d", ifName, index)
 		singleConfig.Master = masterName
 		confBytes, err := json.Marshal(singleConfig)
@@ -56,18 +57,14 @@ func loadIPVANConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*current
 
 		if n.IsMultiNICIPAM {
 			// multi-NIC IPAM config
-			if index < len(ipConfigs) {
-				confBytes = injectMultiNicIPAM(confBytes, ipConfigs, index)
-				confBytesArray = append(confBytesArray, confBytes)
-			}	
+			confBytes = injectMultiNicIPAM(confBytes, ipConfigs, index)
 		} else {
 			confBytes = injectSingleNicIPAM(confBytes, bytes)
-			confBytesArray = append(confBytesArray, confBytes)
 		}
+		confBytesArray = append(confBytesArray, confBytes)
 	}
 	return confBytesArray, nil
 }
-
 
 // copyIPVLANConfig makes a copy of base IPVLAN config
 func copyIPVLANConfig(original IPVLANTypeNetConf) (*IPVLANTypeNetConf, error) {

--- a/cni/plugins/main/multi-nic/sriov.go
+++ b/cni/plugins/main/multi-nic/sriov.go
@@ -2,19 +2,19 @@
  * Copyright 2022- IBM Inc. All rights reserved
  * SPDX-License-Identifier: Apache2.0
  */
- 
+
 package main
 
 import (
 	"encoding/json"
 	"fmt"
-	current "github.com/containernetworking/cni/pkg/types/100"
+
 	"github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
 )
 
-
 // SRIOVNetConfig defines sriov net config
-// references: 
+// references:
 // - https://github.com/openshift/sriov-cni/blob/dfbc68063bb549910a5440d7c80e45a2519d12cc/pkg/config/config.go
 // - https://github.com/k8snetworkplumbingwg/sriov-cni/blob/v2.1.0/cmd/sriov/main.go
 type SRIOVNetConfig struct {
@@ -34,6 +34,7 @@ type SriovNetConf struct {
 	HostIFNames string // VF netdevice name(s)
 	ContIFNames string // VF names after in the container; used during deletion
 }
+
 // loadSRIOVConf unmarshal to SRIOVNetConfig and returns list of SR-IOV configs
 func loadSRIOVConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*current.IPConfig) ([][]byte, error) {
 	confBytesArray := [][]byte{}
@@ -61,14 +62,11 @@ func loadSRIOVConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*current
 		}
 		if n.IsMultiNICIPAM {
 			// multi-NIC IPAM config
-			if index < len(ipConfigs) {
-				confBytes = injectMultiNicIPAM(confBytes, ipConfigs, index)
-				confBytesArray = append(confBytesArray, confBytes)
-			}	
+			confBytes = injectMultiNicIPAM(confBytes, ipConfigs, index)
 		} else {
 			confBytes = injectSingleNicIPAM(confBytes, bytes)
-			confBytesArray = append(confBytesArray, confBytes)
 		}
+		confBytesArray = append(confBytesArray, confBytes)
 	}
 	return confBytesArray, nil
 }
@@ -86,4 +84,3 @@ func copySRIOVconfig(original *SriovNetConf) (*SriovNetConf, error) {
 	}
 	return copiedObject, nil
 }
-


### PR DESCRIPTION
The confBytesArray length check in v1.0.3 on deletion and check is not critical but good to inform. 
This is related to previous bug in v1.0.2 where there is no ipConfig return from ipam and then cause `confBytesArray` to be zero config.

This PR adds empty ipam config when no ipConfig assigned to the device. So, the device (e.g., ipvlan) can still be called ExecDel even if there is no chained ipam. 

Related issue: https://github.com/foundation-model-stack/multi-nic-cni/issues/69

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>