### PR TITLE
Separate daemon test from build CI workload and always check test on PR to main

### DIFF
--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -23,8 +23,6 @@ jobs:
           go-version: '1.17.0'
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
-      - name: Test
-        run: make test-daemon
       - name: Update CNI
         run: make update-cni-local
         working-directory: daemon

--- a/.github/workflows/daemon_unittest.yaml
+++ b/.github/workflows/daemon_unittest.yaml
@@ -1,0 +1,28 @@
+name: Perform unittest for daemon
+
+on:
+  pull_request:
+    paths:
+      - daemon/**
+      - cni/**
+      - Makefile
+  push:
+    paths:
+      - daemon/**
+      - cni/**
+      - Makefile
+
+jobs:
+  build-push-daemon:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-daemon
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Test
+        run: make test-daemon

--- a/.github/workflows/daemon_unittest.yaml
+++ b/.github/workflows/daemon_unittest.yaml
@@ -2,10 +2,8 @@ name: Perform unittest for daemon
 
 on:
   pull_request:
-    paths:
-      - daemon/**
-      - cni/**
-      - Makefile
+    branches:
+      - main
   push:
     paths:
       - daemon/**

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,17 +2,8 @@ name: e2e test
 
 on:
   pull_request:
-    paths:
-      - controllers/**
-      - compute/**
-      - plugin/**
-      - ./main.go
-      - ./go.mod
-      - config/**
-      - ./Dockerfile
-      - ./bundle.Dockerfile
-      - ./Makefile
-      - e2e-test/**
+    branches:
+      - main
   push:
     paths:
       - controllers/**

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -2,14 +2,8 @@ name: Perform unittest for controller
 
 on:
   pull_request:
-    paths:
-      - controllers/**
-      - compute/**
-      - plugin/**
-      - ./main.go
-      - ./go.mod
-      - ./bundle.Dockerfile
-      - ./Makefile
+    branches:
+      - main
   push:
     paths:
       - controllers/**


### PR DESCRIPTION
This PR updates CI workload two points:
- Separate daemon_unittest from build_push_daemon CI
- Change folder-based check to check unit test and scale test on all PR. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>