### PR TITLE
also remove finalizer when snapshot

### DIFF
--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -20,7 +20,7 @@ _snapshot_resource() {
 _snapshot() {
     dir=$1
     cr=$2
-    itemlist=$(kubectl get $cr -ojson |jq '.items'| jq 'del(.[].status,.[].metadata.resourceVersion,.[].metadata.uid,.[].metadata.selfLink,.[].metadata.creationTimestamp,.[].metadata.generation,.[].metadata.ownerReferences)') 
+    itemlist=$(kubectl get $cr -ojson |jq '.items'| jq 'del(.[].status,.[].metadata.finalizers,.[].metadata.resourceVersion,.[].metadata.uid,.[].metadata.selfLink,.[].metadata.creationTimestamp,.[].metadata.generation,.[].metadata.ownerReferences)') 
     echo {"apiVersion": "v1", "items": $itemlist, "kind": "List"}| yq eval - -P > $dir/$cr.yaml
 }
 


### PR DESCRIPTION
Related to https://github.com/foundation-model-stack/multi-nic-cni/issues/74, in the snapshot script, the finalizer must be also deleted.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>