### PR TITLE
add live iperf3 to migration instruction

### DIFF
--- a/live-migration/README.md
+++ b/live-migration/README.md
@@ -5,20 +5,27 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
 - [yq](https://github.com/mikefarah/yq/#install)
 - [watch](https://www.2daygeek.com/linux-watch-command-to-monitor-a-command/) - optional
 
-### Steps
-1. Prepare script and environment
+### Pre-steps
+1. Clone and make script be executable
+    ```bash
+    git clone https://github.com/foundation-model-stack/multi-nic-cni.git
+    cd multi-nic-cni/live_migration
+    chmod +x ./live_migrate.sh
+    ```
+2. If operator is not installed in the `openshift-operators` namespace, run
+    ```bash
+    export OPERATOR_NAMESPACE=<deployed-namespace>
+    ```
+3. To confirm that there is no interruption to deployed pods, try live iperf3 between any two nodes with at least one secondary NIC on another terminal:
+    ```bash
+    export SERVER_HOST_NAME=<target-server-node-name>
+    export CLIENT_HOST_NAME=<target-client-node-name>
+    export LIVE_TIME=2000 # expected time to perform migration (s)
+    ./live_migrate.sh live_iperf3 ${SERVER_HOST_NAME} ${CLIENT_HOST_NAME} ${LIVE_TIME}
+    ```
+### Live Migration Steps
 
-   1.1 Clone and make script be executable
-   ```bash
-   git clone https://github.com/foundation-model-stack/multi-nic-cni.git
-   cd multi-nic-cni/live_migration
-   chmod +x ./live_migrate.sh
-   ```
-   1.2 If operator is not installed in the `openshift-operators` namespace, run
-   ```bash
-   export OPERATOR_NAMESPACE=<deployed-namespace>
-   ```
-2. Snapshot multi-nic-cni CR on your cluster
+1. Snapshot multi-nic-cni CR on your cluster
     ```bash
     export CLUSTER_NAME=<cluster-name> # snapshot is saved to `snapshot/default` folder if not set
     ./live_migrate.sh snapshot
@@ -31,9 +38,9 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     saved in snapshot/<cluster-name>
     ```
     This will create a folder containing relevant CR and update multinetwork name in `multinicnetwork_l2.yaml`
-3. Deactivate controller from updating route on host
+2. Deactivate controller from updating route on host
 
-    3.1 Deactivate route configuration
+    2.1 Deactivate route configuration
     ```bash
     ./live_migrate.sh deactivate_route_config
     ```
@@ -42,42 +49,42 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     multinicnetwork.multinic.fms.io/<multinicnetwork-name> configured
     Deactivate route configuration.
     ```
-    3.2 For migrating to new channel with updated CRDs, clean the old resources first.
+    2.2 For migrating to new channel with updated CRDs, clean the old resources first.
     ```bash
     ./live_migrate.sh clean_resource
     ```
 
-4. Uninstall operator
+3. Uninstall operator
 
-    4.1 Uninstall by CLI
+    3.1 Uninstall by CLI
     ```bash
     OLD_VERSION=<version-to-uninstall> # e.g., OLD_VERSION=1.0.2
     ./live_migrate.sh uninstall_operator $OLD_VERSION 
     ```
     For OperatorSDK, run `operator-sdk cleanup multi-nic-cni-operator --delete-all`<br>
-    4.2 Wait until all multi-nicd daemon is terminated<br>
+    3.2 Wait until all multi-nicd daemon is terminated<br>
     ```bash
     ./live_migrate.sh wait_daemon_terminated
     ```
-    4.3 For migrating to new channel with updated CRDs, need to also clean CRD.
+    3.3 For migrating to new channel with updated CRDs, need to also clean CRD.
     ```bash
     ./live_migrate.sh clean_crd
     ```
 
-5. Reinstall operator
+4. Reinstall operator
    
-    5.1 install operator via GUI (recommended). For other installation, check [Installation Guide](https://foundation-model-stack.github.io/multi-nic-cni/user_guide/#quick-installation).
+    4.1 install operator via GUI (recommended). For other installation, check [Installation Guide](https://foundation-model-stack.github.io/multi-nic-cni/user_guide/#quick-installation).
 
-    5.2 If multi-nicd image also need to be updated, run
+    4.2 If multi-nicd image also need to be updated, run
     ```bash
     ./live_migrate.sh patch_daemon
     ```
 
-    5.3 Wait until multi-nicd daemon is all running:
+    4.3 Wait until multi-nicd daemon is all running:
     ```bash
     ./live_migrate.sh wait_daemon
     ```
-    5.4 Check if CRs are deleted or not (not deleted by default):
+    4.4 Check if CRs are deleted or not (not deleted by default):
     ```bash
     kubectl get cidr
     ```
@@ -85,9 +92,9 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     # expected output if CRs are deleted
     No resources found
     ```
-    If CRs are deleted (for example, by operator-sdk cleanup or with CRD updates, by updated CDR), do 5.5 - 5.7
+    If CRs are deleted (for example, by operator-sdk cleanup or with CRD updates, by updated CDR), do 4.5 - 4.7
     
-    5.5 deploy dump multinicnetwork
+    4.5 deploy dump multinicnetwork
     ```bash
     ./live_migrate.sh deactivate_route_config
     ```
@@ -96,11 +103,11 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     multinicnetwork.multinic.fms.io/<multinicnetwork-name> configured
     Deactivate route configuration.
     ```
-    5.6 apply snapshot status CR
+    4.6 apply snapshot status CR
     ```bash
     ./live_migrate.sh deploy_status_cr
     ```
-    5.7 restart controller to activate cache initialization
+    4.7 restart controller to activate cache initialization
     ```bash
     ./live_migrate.sh restart_controller
     ```
@@ -113,7 +120,7 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     Config Ready
     ```
 
-6. Activate route config
+5. Activate route config
     ```bash
     ./live_migrate.sh activate_route_config
     ```
@@ -123,7 +130,7 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     Activate route configuration.
     ```
     
-7. Check multinicnetwork status (available from v1.0.3)
+6. Check multinicnetwork status (available from v1.0.3)
    ```bash
    ./live_migrate.sh get_status
     ```

--- a/live-migration/test/iperf3/client.yaml
+++ b/live-migration/test/iperf3/client.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-nic-iperf3-client
+  annotations:
+    k8s.v1.cni.cncf.io/networks: netname
+spec:
+  containers:
+  - name: server
+    image: networkstatic/iperf3
+    command: ["tail", "-f", "/dev/null"]
+    imagePullPolicy: IfNotPresent
+  nodeName: hostname

--- a/live-migration/test/iperf3/server.yaml
+++ b/live-migration/test/iperf3/server.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-nic-iperf3-server
+  annotations:
+    k8s.v1.cni.cncf.io/networks: netname
+spec:
+  containers:
+  - name: server
+    image: networkstatic/iperf3
+    command: ["/bin/bash", "-c"]
+    args:
+    - "iperf3 -s"
+    imagePullPolicy: IfNotPresent
+  nodeName: hostname


### PR DESCRIPTION
According to https://github.com/foundation-model-stack/multi-nic-cni/issues/76, this PR provides a script to deploy iperf3 server and client pods as a pre-step. Then, execute the client iperf3 request to secondary IP of server pod for a specified live period. 


Example output with short live period (5s): 
```bash
# ./live_migrate.sh live_iperf3 ${SERVER_HOST_NAME} ${CLIENT_HOST_NAME} 5
pod/multi-nic-iperf3-server created
pod/multi-nic-iperf3-server condition met
pod/multi-nic-iperf3-client created
pod/multi-nic-iperf3-client condition met
Connecting to host 192.168.0.4, port 5201
[  5] local 192.168.0.132 port 37228 connected to 192.168.0.4 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   140 MBytes  1.17 Gbits/sec    0   3.01 MBytes
[  5]   1.00-2.00   sec   120 MBytes  1.01 Gbits/sec   45   2.21 MBytes
[  5]   2.00-3.00   sec   121 MBytes  1.02 Gbits/sec    0   2.41 MBytes
[  5]   3.00-4.00   sec   120 MBytes  1.01 Gbits/sec    0   2.56 MBytes
[  5]   4.00-5.00   sec   121 MBytes  1.02 Gbits/sec    0   2.69 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec   622 MBytes  1.04 Gbits/sec   45             sender
[  5]   0.00-5.07   sec   621 MBytes  1.03 Gbits/sec                  receiver

iperf Done.
pod "multi-nic-iperf3-client" deleted
pod "multi-nic-iperf3-server" deleted
```

Kindly check `live-migration/README.md`.



Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>