### PR TITLE
Fix unexpected re-computation of CIDR after restarting multi-nicd

### DIFF
--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -114,7 +114,7 @@ func (r *HostInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	hifName := instance.GetName()
-	if !r.HostInterfaceHandler.SafeCache.Contains(hifName) {
+	if !r.HostInterfaceHandler.SafeCache.Contains(hifName) && len(instance.Spec.Interfaces) > 0 {
 		r.HostInterfaceHandler.SetCache(hifName, *instance.DeepCopy())
 	}
 


### PR DESCRIPTION
This PR is supposed to solve the issue https://github.com/foundation-model-stack/multi-nic-cni/issues/78.
When restarting multi-nicd, interface list is init with empty until it is available from multi-nicd. 

The main point to fix is not setting HostInterface cache if the interface list is not available. 

This PR also includes
- awareness of the case that NewCIDRWithConfig is called when CIDR exists but cannot get by API server (server busy). 
- congestion on updating multinicnetwork status from Daemon pod update, HostInterface update, CIDR update

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>