### PR TITLE
add resilience test and correct CI flow and script

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -77,9 +77,13 @@ jobs:
         shell: bash
       - name: Test allocate/deallocate
         working-directory: ./e2e-test
-        run: ./script.sh test_taint
+        run: ./script.sh test_allocate
         shell: bash
       - name: Test taint/untaint
         working-directory: ./e2e-test
         run: ./script.sh test_taint
+        shell: bash
+      - name: Test resilience
+        working-directory: ./e2e-test
+        run: ./script.sh test_resilience
         shell: bash


### PR DESCRIPTION
This PR implements resilience test as  posted in https://github.com/foundation-model-stack/multi-nic-cni/issues/80.

Additionally, this PR also
- fix test_allocate script typo in CI
- add delay traffic when detect fake node failure

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>