### PR TITLE
Fix NotFound error on wait_daemon in live migration script

### DIFF
--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -162,7 +162,15 @@ patch_daemon() {
 }
 
 wait_daemon() {
+    # wait for daemon creation
     sleep 5
+    daemonCreate=$(kubectl get ds multi-nicd -n ${OPERATOR_NAMESPACE}|wc -l|tr -d ' ')
+    while [ "$daemonCreate" == 0 ] ; 
+    do
+        echo "Wait for daemonset to be created by controller..."
+        sleep 2
+        daemonCreate=$(kubectl get ds multi-nicd -n ${OPERATOR_NAMESPACE}|wc -l|tr -d ' ')
+    done
     echo "Wait for daemonset to be ready"
     kubectl rollout status daemonset multi-nicd -n ${OPERATOR_NAMESPACE} --timeout 300s
 }


### PR DESCRIPTION
According to https://github.com/foundation-model-stack/multi-nic-cni/issues/82, this PR adds while loop to check and wait for multi-nicd to be created by controller. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>