### PR TITLE
change IMAGE_VERSION to v1.1.0

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -8,7 +8,7 @@ on:
       - connection-check/**
 
 env:
-  IMAGE_VERSION: '1.0.2'
+  IMAGE_VERSION: '1.1.0'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -16,7 +16,7 @@ on:
       - ./Makefile
 
 env:
-  VERSION: '1.0.3'
+  VERSION: '1.1.0'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -10,7 +10,7 @@ on:
       - Makefile
       
 env:
-  IMAGE_VERSION: '1.0.3'
+  IMAGE_VERSION: '1.1.0'
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # VERSION ?= 0.0.1
-VERSION ?= 1.0.3
+VERSION ?= 1.1.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ namespaces| (optional) limit network definition application to list of namespace
   ```
 ##### by bundle with operator-sdk
   ```bash
-  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.0.3
+  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.1.0
   ```
 #### Deploy MultiNicNetwork resource
 1. Prepare `network.yaml` as shown in the [example](#multinicnetwork)

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -118,7 +118,7 @@ func (r *ConfigReconciler) CreateDefaultDaemonConfig() error {
 		Privileged: &privileged,
 	}
 	daemonSpec := multinicv1.DaemonSpec{
-		Image:           "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.0.3",
+		Image:           "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.1.0",
 		Env:             env,
 		HostPathMounts:  hostPathMounts,
 		Resources:       resources,


### PR DESCRIPTION
This PR moves the build to v1.1.0 tag regarding https://github.com/foundation-model-stack/multi-nic-cni/milestone/1.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>