### PR TITLE
make controller support aws-ipvlan plugin and update connection-check

### DIFF
--- a/config/samples/multinicnetwork/awsipvlan.yaml
+++ b/config/samples/multinicnetwork/awsipvlan.yaml
@@ -1,0 +1,18 @@
+apiVersion: multinic.fms.io/v1
+kind: MultiNicNetwork
+metadata:
+  name: multinic-aws-ipvlan
+spec:
+  ipam: |
+    {
+      "type": "multi-nic-ipam",
+      "hostBlock": 8, 
+      "interfaceBlock": 2,
+      "vlanMode": "l2"
+    }
+  multiNICIPAM: true
+  plugin:
+    cniVersion: "0.3.0"
+    type: aws-ipvlan
+    args: 
+      mode: l2

--- a/connection-check/concheck.yaml
+++ b/connection-check/concheck.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: multi-nic-concheck-account
       containers:
       - name: concheck
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.0.2
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/connection-check/main.go
+++ b/connection-check/main.go
@@ -60,20 +60,20 @@ func main() {
 		log.Printf("%d/%d servers successfully created", totalCount, len(podCIDRsMap))
 		// wait for server ready
 		var ipMaps map[string][]string
+		var primaryIPMap map[string]string
 		var serversReady bool
 		for {
-			ipMaps, serversReady = iperfHanlder.CheckServers(DEFAULT_NAMESPACE, cidrName, totalCount)
+			primaryIPMap, ipMaps, serversReady = iperfHanlder.CheckServers(DEFAULT_NAMESPACE, cidrName, totalCount)
 			time.Sleep(5 * time.Second)
 			if serversReady {
 				break
 			}
-
 		}
 
 		// create iperf client job for listed related hosts with cidr multi-nic-network
 		totalCount = 0
 		for host, _ := range podCIDRsMap {
-			job, err := iperfHanlder.CreateClientJob(DEFAULT_NAMESPACE, cidrName, host, ipMaps)
+			job, err := iperfHanlder.CreateClientJob(DEFAULT_NAMESPACE, cidrName, host, primaryIPMap, ipMaps)
 
 			if err != nil {
 				log.Printf("Cannot create client job for %s, %s: %v", cidrName, host, err)

--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -236,6 +236,9 @@ func (h *CIDRHandler) GetAllNetAddrs() []string {
 
 // newCIDR returns new CIDR from PluginConfig
 func (h *CIDRHandler) newCIDR(def multinicv1.PluginConfig, namespace string) (multinicv1.CIDRSpec, error) {
+	if def.Subnet == "" {
+		return h.generateCIDRFromHostSubnet(def)
+	}
 	entries := []multinicv1.CIDREntry{}
 	masterIndex := int(0)
 	// maxInterfaceIndex = 2^(interface bits) - 1
@@ -476,6 +479,11 @@ func (h *CIDRHandler) updateCIDR(cidrSpec multinicv1.CIDRSpec, new bool) (bool, 
 	}
 	h.Mutex.Lock()
 	def := cidrSpec.Config
+	excludesInStr := []string{}
+	excludesInStr = append(excludesInStr, def.ExcludeCIDRs...)
+	if def.Subnet == "" {
+		excludesInStr = append(excludesInStr, h.getHostAddressesToExclude()...)
+	}
 	excludes := compute.SortAddress(def.ExcludeCIDRs)
 	h.Log.V(7).Info(fmt.Sprintf("Update CIDR %s", def.Name))
 	entriesMap, changed := h.updateEntries(cidrSpec, excludes, new)
@@ -782,6 +790,17 @@ func (h *CIDRHandler) getInterfaceEntry(def multinicv1.PluginConfig, entriesMap 
 		// already exists
 		return true, entry
 	}
+	if def.Subnet == "" {
+		// set static entry index to latest
+		index := len(entriesMap)
+		entry := multinicv1.CIDREntry{
+			NetAddress:     newNetAdress,
+			InterfaceIndex: index,
+			VlanCIDR:       newNetAdress,
+			Hosts:          []multinicv1.HostInterfaceInfo{},
+		}
+		return true, entry
+	}
 	var excludedIndexes []int
 	for _, entry := range entriesMap {
 		index := entry.InterfaceIndex
@@ -895,6 +914,65 @@ func (h *CIDRHandler) GetHostInterfaceIndexMap(entries []multinicv1.CIDREntry) m
 		}
 	}
 	return hostInterfaceIndexMap
+}
+
+// generateCIDRFromHostSubnet generates CIDR from Host Subnet
+// in the case that podCIDR must be shared with host subnet (e.g., in aws VPC)
+func (h *CIDRHandler) generateCIDRFromHostSubnet(def multinicv1.PluginConfig) (multinicv1.CIDRSpec, error) {
+	vlanIndexMap := make(map[string]int)
+	entryMap := make(map[string]multinicv1.CIDREntry)
+	lastIndex := 0
+
+	// maxHostIndex = 2^(host bits) - 1
+	maxHostIndex := int(math.Pow(2, float64(def.HostBlock)) - 1)
+
+	snapshot := h.HostInterfaceHandler.ListCache()
+	for hostName, hif := range snapshot {
+		for _, iface := range hif.Spec.Interfaces {
+			netAddr := iface.NetAddress
+			if _, exist := vlanIndexMap[netAddr]; !exist {
+				// new address
+				vlanIndexMap[netAddr] = lastIndex
+				entry := multinicv1.CIDREntry{
+					NetAddress:     netAddr,
+					InterfaceIndex: vlanIndexMap[netAddr],
+					VlanCIDR:       netAddr,
+					Hosts:          []multinicv1.HostInterfaceInfo{},
+				}
+				entryMap[netAddr] = entry
+				lastIndex += 1
+			}
+			entry := entryMap[netAddr]
+			entry, changed := h.tryAddNewHost(entry.Hosts, entry, maxHostIndex, def, hostName, iface.InterfaceName, iface.HostIP)
+			if !changed {
+				return multinicv1.CIDRSpec{}, fmt.Errorf("failed to add host to CIDR entry")
+			}
+			entryMap[netAddr] = entry
+		}
+	}
+	entries := []multinicv1.CIDREntry{}
+	for _, entry := range entryMap {
+		entries = append(entries, entry)
+	}
+	cidrSpec := multinicv1.CIDRSpec{
+		Config: def,
+		CIDRs:  entries,
+	}
+	return cidrSpec, nil
+}
+
+// getHostAddressesToExclude returns host addresses to be excluded
+// in the case that dedicated podCIDR must be shared with host subnet (e.g., in aws VPC)
+func (h *CIDRHandler) getHostAddressesToExclude() []string {
+	excludes := []string{}
+	snapshot := h.HostInterfaceHandler.ListCache()
+	for _, hif := range snapshot {
+		for _, iface := range hif.Spec.Interfaces {
+			hostIPCIDR := fmt.Sprintf("%s/32", iface.HostIP)
+			excludes = append(excludes, hostIPCIDR)
+		}
+	}
+	return excludes
 }
 
 // handling CIDRCache

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -136,4 +136,19 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		contains, index = multinicnetworkReconciler.CIDRHandler.CIDRCompute.GetIndexInRange(podCIDR, unsyncedIp)
 		Expect(contains).To(Equal(false))
 	})
+
+	It("Empty subnet", func() {
+		emptySubnetMultinicnetwork := getMultiNicCNINetwork("empty-ipam", cniVersion, cniType, cniArgs)
+		emptySubnetMultinicnetwork.Spec.Subnet = ""
+		ipamConfig, err := multinicnetworkReconciler.getIPAMConfig(emptySubnetMultinicnetwork)
+		ipamConfig.InterfaceBlock = 0
+		ipamConfig.HostBlock = 4
+		Expect(err).NotTo(HaveOccurred())
+		cidrSpec, err := multinicnetworkReconciler.CIDRHandler.generateCIDRFromHostSubnet(*ipamConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(cidrSpec.CIDRs)).To(Equal(len(interfaceNames)))
+		fmt.Println(cidrSpec)
+		hostIPs := multinicnetworkReconciler.CIDRHandler.getHostAddressesToExclude()
+		Expect(len(hostIPs)).To(BeEquivalentTo(len(interfaceNames) * multinicnetworkReconciler.CIDRHandler.HostInterfaceHandler.GetSize()))
+	})
 })

--- a/controllers/multinicnetwork_controller.go
+++ b/controllers/multinicnetwork_controller.go
@@ -54,9 +54,16 @@ func GetPluginMap(config *rest.Config, logger logr.Logger) map[string]*PluginInt
 		Log: logger,
 	}
 	pluginMap[plugin.SRIOV_TYPE] = new(PluginInterface)
-	sriovPlugin := &plugin.SriovPlugin{Log: logger}
+	sriovPlugin := &plugin.SriovPlugin{
+		Log: logger,
+	}
 	sriovPlugin.Init(config)
 	*pluginMap[plugin.SRIOV_TYPE] = sriovPlugin
+	pluginMap[plugin.AWS_IPVLAN_TYPE] = new(PluginInterface)
+	awsVpcCNIPlugin := &plugin.AwsVpcCNIPlugin{
+		Log: logger,
+	}
+	*pluginMap[plugin.AWS_IPVLAN_TYPE] = awsVpcCNIPlugin
 	return pluginMap
 }
 

--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -240,7 +240,7 @@ live_iperf3() {
    # wait until client available
    kubectl wait pod ${CLIENT_NAME} --for condition=ready --timeout=90s
    # run live client
-   kubectl exec -it ${CLIENT_NAME} -- iperf3 -c ${SECONDARY_IP} -t ${LIVE_TIME}
+   kubectl exec -it ${CLIENT_NAME} -- iperf3 -c ${SECONDARY_IP} -t ${LIVE_TIME} -p 30000
 
    # clean up
    kubectl delete pod ${CLIENT_NAME} ${SERVER_NAME}

--- a/live-migration/test/iperf3/server.yaml
+++ b/live-migration/test/iperf3/server.yaml
@@ -10,6 +10,6 @@ spec:
     image: networkstatic/iperf3
     command: ["/bin/bash", "-c"]
     args:
-    - "iperf3 -s"
+    - "iperf3 -s -p 30000"
     imagePullPolicy: IfNotPresent
   nodeName: hostname

--- a/plugin/awsipvlan.go
+++ b/plugin/awsipvlan.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package plugin
+
+import (
+	"encoding/json"
+
+	"github.com/containernetworking/cni/pkg/types"
+	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	AWS_IPVLAN_TYPE = "aws-ipvlan"
+)
+
+type AwsVpcCNIPlugin struct {
+	Log logr.Logger
+}
+
+type AWSIPVLANNetConf struct {
+	types.NetConf
+	PrimaryIP map[string]interface{} `json:"primaryIP"`
+	PodIP     string                 `json:"podIP"`
+	Master    string                 `json:"master"`
+	Mode      string                 `json:"mode"`
+	MTU       int                    `json:"mtu"`
+}
+
+func (p *AwsVpcCNIPlugin) Init(config *rest.Config, logger logr.Logger) error {
+	return nil
+}
+
+func (p *AwsVpcCNIPlugin) GetConfig(net multinicv1.MultiNicNetwork, hifList map[string]multinicv1.HostInterface) (string, map[string]string, error) {
+	spec := net.Spec.MainPlugin
+	args := spec.CNIArgs
+	conf := &AWSIPVLANNetConf{}
+	argBytes, _ := json.Marshal(args)
+	json.Unmarshal(argBytes, conf)
+	conf.CNIVersion = net.Spec.MainPlugin.CNIVersion
+	conf.Type = AWS_IPVLAN_TYPE
+	val, err := getInt(args, "mtu")
+	if err == nil {
+		conf.MTU = val
+	}
+	confBytes, err := json.Marshal(conf)
+	if err != nil {
+		return "", make(map[string]string), err
+	}
+	return string(confBytes), make(map[string]string), nil
+}
+
+func (p *AwsVpcCNIPlugin) CleanUp(net multinicv1.MultiNicNetwork) error {
+	return nil
+}


### PR DESCRIPTION
Corresponding to https://github.com/foundation-model-stack/multi-nic-cni/issues/60, https://github.com/foundation-model-stack/multi-nic-cni/pull/61, this PR rebased https://github.com/foundation-model-stack/multi-nic-cni/pull/62 from v1.0.3 to support aws-ipvlan plugin. 

- Generate CIDR based on Host subnet instead of pre-defined subnet
- Add awsipvlan plugin interface and add to pluginMap

As it will use the host subnet and only common nodeport range is open, this PR also updates connection check image and script to use ports in that range (3000x). 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>