### PR TITLE
set workflow branch to v1.0.3

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -3,10 +3,11 @@ name: Build and push connection check image
 on:
   push:
     branches:
-      - main
+      - v1.0.3
     paths:
       - connection-check/**
-
+      - .github/workflows/**
+      
 env:
   IMAGE_VERSION: '1.0.2'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -3,7 +3,7 @@ name: Build and push controller and its bundle image
 on:
   push:
     branches:
-      - main
+      - v1.0.3
     paths:
       - controllers/**
       - compute/**
@@ -14,6 +14,7 @@ on:
       - ./Dockerfile
       - ./bundle.Dockerfile
       - ./Makefile
+      - .github/workflows/**
 
 env:
   VERSION: '1.0.3'

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -3,11 +3,12 @@ name: Build and push daemon image
 on:
   push:
     branches:
-      - main
+      - v1.0.3
     paths:
       - daemon/**
       - cni/**
       - Makefile
+      - .github/workflows/**
       
 env:
   IMAGE_VERSION: '1.0.3'


### PR DESCRIPTION
This PR set the workflow branch to v1.0.3 to rebuild the image on push to the release tag.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

