### PR TITLE
add alert rules and fix privileged-cr naming

### DIFF
--- a/health-check/Makefile
+++ b/health-check/Makefile
@@ -45,6 +45,6 @@ deploy: deploy-agent
 	@./checker/script.sh deploy
 
 clean:
-	@kubectl delete -f ./checker/deployment.yaml
-	@kubectl delete -f ./checker/rbac.yaml
-	@kubectl delete -f ./sidecar/manifest.yaml
+	@kubectl delete -f ./checker/deployment.yaml  && echo "Completely delete checkers" || echo "Failed to clean checkers"  
+	@kubectl delete -f ./checker/rbac.yaml && echo "Completely delete RBAC resource of checkers" || echo "Failed to clean RBAC resource of checkers"  
+	@kubectl delete -f ./sidecar/manifest.yaml && echo "Completely delete agents" || echo "Failed to clean agents"  

--- a/health-check/checker/rbac.yaml
+++ b/health-check/checker/rbac.yaml
@@ -152,3 +152,48 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
   namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    multi-nic-cni-component: health-checker
+    app: multi-nic-cni
+  name: multi-nic-cni-health-checker-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: MultiNICFailure
+    rules:
+    - alert: MultiNICFunctionalityCheckFailed
+      expr: multi_nic_cni_allocability{host!~".*master.*"} != 2
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Multi-NIC CNI {{ $labels.network }} may fail to create/delete pods on host {{ $labels.host }}"
+        description: "Checker {{ $labels.checker }} has failed to confirm functionality of Multi-NIC CNI on host {{ $labels.host }} from last 30min due to {{ $labels.message }} reason.\n Functional network is {{ $value }} of 2. Check /status for more information."
+    - alert: MultiNICConnectivityCheckFailed
+      expr: multi_nic_cni_connectivity{host!~".*master.*"} != 1
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Pods on host {{ $labels.host }} may have a connection failure in the secondary network {{ $labels.networkaddress }} of {{ $labels.network }}"
+        description: "Checker {{ $labels.checker }} has failed to confirm Multi-NIC connectivity of the secondary network {{ $labels.networkaddress }} of {{ $labels.network }} for pods on host {{ $labels.host }} from last 30min.\n Check /status for more information."
+    - alert: MultiNICAllFunctionalityCheckFailed
+      expr: (count(multi_nic_cni_allocability{host!~".*master.*"}) by (checker) > 0) and (sum(multi_nic_cni_allocability) by (checker) == 0)
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Checker {{ $labels.checker }} cannot check functionality on any host"
+        description: "Checker {{ $labels.checker }} has failed to confirm functionality of Multi-NIC CNI on any host. \n Checker can be itself non-functional on primary networks.\n If there is secondary network enabled, confirm that the checker port (default: 11001) is allowed."
+    - alert: MultiNICAllConnectivityCheckFailed
+      expr: (count(multi_nic_cni_allocability{host!~".*master.*"}) by (checker) > 0) and (sum(multi_nic_cni_allocability) by (checker) > 0) and (sum(multi_nic_cni_connectivity) by (checker) == 0)
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Checker {{ $labels.checker }} cannot check connectivity on any host"
+        description: "Checker {{ $labels.checker }} has failed to confirm connectivity of Multi-NIC CNI on any host. \n Checker can be itself unconnected on secondary networks.\n Try redeploying the checker on the different host or increasing the number of checker replicas."

--- a/health-check/checker/script.sh
+++ b/health-check/checker/script.sh
@@ -29,7 +29,6 @@ deploy() {
     echo "Set network name ${NETWORK_NAME}"
     NETWORK_REPLACEMENT=$(create_replacement .spec.template.metadata.annotations.\"k8s.v1.cni.cncf.io/networks\" \"${NETWORK_NAME}\")
     apply ${NETWORK_REPLACEMENT} ./checker/deployment
-
 }
 
 "$@"

--- a/health-check/sidecar/manifest.yaml
+++ b/health-check/sidecar/manifest.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: privileged-cr
+  name: multi-nic-privileged-cr
 rules:
 - apiGroups:
   - security.openshift.io
@@ -28,7 +28,7 @@ subjects:
   namespace: openshift-operators
 roleRef:
   kind: ClusterRole
-  name: privileged-cr
+  name: multi-nic-privileged-cr
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Regarding this https://github.com/foundation-model-stack/multi-nic-cni/issues/99, this main objective of this PR is to add PrometheusRule for adding alerting rules according to prometheus query exported by mutli-nic cni health checker. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>