### PR TITLE
Fix HostInterface Reconcile, CNI Del/Check, and DaemonSet priorityclass

### DIFF
--- a/cni/plugins/main/multi-nic/multi-nic.go
+++ b/cni/plugins/main/multi-nic/multi-nic.go
@@ -182,7 +182,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	n, deviceType, err := loadConf(args)
 	if err != nil {
-		return fmt.Errorf("fail to load conf: %v", err)
+		utils.Logger.Debug(fmt.Sprintf("fail to load conf: %v", err))
+		return nil
 	}
 	utils.Logger.Debug(fmt.Sprintf("Received an DEL request for: conf=%v", n))
 	// On chained invocation, IPAM block can be empty
@@ -199,12 +200,13 @@ func cmdDel(args *skel.CmdArgs) error {
 	// parse previous result
 	if n.NetConf.RawPrevResult != nil {
 		if err = version.ParsePrevResult(&n.NetConf); err != nil {
-			return fmt.Errorf("could not parse prevResult: %v", err)
+			utils.Logger.Debug(fmt.Sprintf("could not parse prevResult: %v", err))
+			return nil
 		}
-
 		result, err = current.NewResultFromResult(n.NetConf.PrevResult)
 		if err != nil {
-			return fmt.Errorf("could not convert result to current version: %v", err)
+			utils.Logger.Debug(fmt.Sprintf("could not convert result to current version: %v", err))
+			return nil
 		}
 	} else {
 		result = &current.Result{CNIVersion: current.ImplementedSpecVersion}
@@ -222,7 +224,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 	if err != nil {
 		utils.Logger.Debug(fmt.Sprintf("Fail loading %v: %v", string(args.StdinData), err))
-		return err
+		return nil
 	}
 	if len(confBytesArray) == 0 {
 		utils.Logger.Debug(fmt.Sprintf("zero config on cmdDel: %v (%d)", string(args.StdinData), len(n.Masters)))
@@ -238,7 +240,6 @@ func cmdDel(args *skel.CmdArgs) error {
 			return nil
 		}
 	}
-
 	return nil
 }
 
@@ -249,19 +250,21 @@ func cmdCheck(args *skel.CmdArgs) error {
 
 	n, deviceType, err := loadConf(args)
 	if err != nil {
-		return fmt.Errorf("fail to load conf")
+		utils.Logger.Debug(fmt.Sprintf("fail to load conf: %v", err))
+		return nil
 	}
 
 	var result *current.Result
 	// parse previous result
 	if n.NetConf.RawPrevResult != nil {
 		if err = version.ParsePrevResult(&n.NetConf); err != nil {
-			return fmt.Errorf("could not parse prevResult: %v", err)
+			utils.Logger.Debug(fmt.Sprintf("could not parse prevResult: %v", err))
+			return nil
 		}
-
 		result, err = current.NewResultFromResult(n.NetConf.PrevResult)
 		if err != nil {
-			return fmt.Errorf("could not convert result to current version: %v", err)
+			utils.Logger.Debug(fmt.Sprintf("could not convert result to current version: %v", err))
+			return nil
 		}
 	} else {
 		result = &current.Result{CNIVersion: current.ImplementedSpecVersion}
@@ -279,7 +282,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 	if err != nil {
 		utils.Logger.Debug(fmt.Sprintf("Fail loading %v: %v", string(args.StdinData), err))
-		return err
+		return nil
 	}
 	if len(confBytesArray) == 0 {
 		utils.Logger.Debug(fmt.Sprintf("zero config on cmdCheck: %v (%d)", string(args.StdinData), len(n.Masters)))
@@ -291,10 +294,10 @@ func cmdCheck(args *skel.CmdArgs) error {
 		utils.Logger.Debug(fmt.Sprintf("Exec %s %s: %s", command, ifName, string(confBytes)))
 		_, err := execPlugin(deviceType, command, confBytes, args, ifName, false)
 		if err != nil {
-			return err
+			utils.Logger.Debug(fmt.Sprintf("Fail execPlugin %v: %v", string(confBytes), err))
+			return nil
 		}
 	}
-
 	return nil
 }
 

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -320,6 +320,7 @@ func (r *ConfigReconciler) newCNIDaemonSet(client *kubernetes.Clientset, name st
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
+					PriorityClassName:  "system-cluster-critical",
 					HostNetwork:        true,
 					ServiceAccountName: vars.ServiceAccountName,
 					NodeSelector:       daemonSpec.NodeSelector,

--- a/controllers/hostinterface_controller.go
+++ b/controllers/hostinterface_controller.go
@@ -122,7 +122,8 @@ func (r *HostInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if !ConfigReady || !r.DaemonWatcher.IsDaemonSetReady() {
-		return ctrl.Result{RequeueAfter: vars.NormalReconcileTime}, nil
+		// only hostinterface must be reconciled urgently after config is ready because it's tightly coupling with daemon
+		return ctrl.Result{RequeueAfter: vars.UrgentReconcileTime}, nil
 	}
 
 	vars.HifLog.V(7).Info(fmt.Sprintf("HostInterface reconciled: %s", instance.ObjectMeta.Name))


### PR DESCRIPTION
This PR includes three fixes for early state config, failure tolerance as follows:
- Change HostInterface Reconcile time from Normal to Urgent when config/daemon is not ready yet.
- Remove err return at Delete and Check of CNI.
- Add ProrityClass to daemon pod to avoid eviction.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>