### PR TITLE
continue after net-attach-def create/udpate error

### DIFF
--- a/plugin/net_attach_def.go
+++ b/plugin/net_attach_def.go
@@ -113,6 +113,7 @@ func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pl
 	if err != nil {
 		return err
 	}
+	errMsg := ""
 	for _, def := range defs {
 		name := def.GetName()
 		namespace := def.GetNamespace()
@@ -122,14 +123,17 @@ func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pl
 			def.ObjectMeta = existingDef.ObjectMeta
 			err := h.DynamicHandler.Update(namespace, def, result)
 			if err != nil {
-				return err
+				errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
 			}
 		} else {
 			err := h.DynamicHandler.Create(namespace, def, result)
 			if err != nil {
-				return err
+				errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
 			}
 		}
+	}
+	if errMsg != "" {
+		return fmt.Errorf(errMsg)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is to fix https://github.com/foundation-model-stack/multi-nic-cni/issues/113 by appending the error message while continue updating in the other namespace. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>