### PR TITLE
cherry-pick continue after net-attach-def create/udpate error 

### DIFF
--- a/cni/plugins/main/multi-nic/multi-nic.go
+++ b/cni/plugins/main/multi-nic/multi-nic.go
@@ -70,6 +70,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// open specified network namespace
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
+		utils.Logger.Debug(fmt.Sprintf("failed to open netns %q: %v", args.Netns, err))
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer netns.Close()
@@ -80,11 +81,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// parse previous result
 	if n.NetConf.RawPrevResult != nil {
 		if err = version.ParsePrevResult(&n.NetConf); err != nil {
+			utils.Logger.Debug(fmt.Sprintf("could not parse prevResult: %v", err))
 			return fmt.Errorf("could not parse prevResult: %v", err)
 		}
 
 		result, err = current.NewResultFromResult(n.NetConf.PrevResult)
 		if err != nil {
+			utils.Logger.Debug(fmt.Sprintf("could not convert result to current version: %v", err))
 			return fmt.Errorf("could not convert result to current version: %v", err)
 		}
 
@@ -97,6 +100,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if !haveResult && n.IsMultiNICIPAM {
+		utils.Logger.Debug(fmt.Sprintf("use multi-nic-ipam: %s", n.IPAM.Type))
 		// run the IPAM plugin and get back the config to apply
 		injectedStdIn := injectMaster(args.StdinData, n.MasterNetAddrs, n.Masters, n.DeviceIDs)
 		r, err := ipam.ExecAdd(n.IPAM.Type, injectedStdIn)

--- a/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
+++ b/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
@@ -107,9 +107,9 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/config/manifests/operator-group.yaml
+++ b/config/manifests/operator-group.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-nic-cni
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: CIDR.v1.multinic.fms.io,Config.v1.multinic.fms.io,DeviceClass.v1.multinic.fms.io,HostInterface.v1.multinic.fms.io,IPPool.v1.multinic.fms.io,MultiNicNetwork.v1.multinic.fms.io
+  name: multi-nic-cni
+  namespace: multi-nic-cni
+spec:
+  staticProvidedAPIs: true

--- a/plugin/net_attach_def.go
+++ b/plugin/net_attach_def.go
@@ -113,6 +113,7 @@ func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pl
 	if err != nil {
 		return err
 	}
+	errMsg := ""
 	for _, def := range defs {
 		name := def.GetName()
 		namespace := def.GetNamespace()
@@ -122,14 +123,17 @@ func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pl
 			def.ObjectMeta = existingDef.ObjectMeta
 			err := h.DynamicHandler.Update(namespace, def, result)
 			if err != nil {
-				return err
+				errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
 			}
 		} else {
 			err := h.DynamicHandler.Create(namespace, def, result)
 			if err != nil {
-				return err
+				errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
 			}
 		}
+	}
+	if errMsg != "" {
+		return fmt.Errorf(errMsg)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR cherry-pick the commit https://github.com/foundation-model-stack/multi-nic-cni/commit/e3ba0e4367e07d39d3bc8347d63b2cb4ff462164 from v1.0.4.

Also, add debug log and change csv resource for supporting deployment on the other namespace.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>