### PR TITLE
fix repo path and cidr compute only defined netaddr

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/sunya-ch/multi-nic-cni-controller
+  newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
   newTag: v1.2.0

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -14,5 +14,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
-  newName: ghcr.io/sunya-ch/multi-nic-cni-daemon
+  newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
   newTag: v1.2.0

--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -388,6 +388,12 @@ func (h *CIDRHandler) UpdateEntries(cidrSpec multinicv1.CIDRSpec, excludes []com
 		excludesInStr = append(excludesInStr, exclude.Address)
 	}
 
+	// initCheckInterfaceMap
+	checkInterfaceMap := make(map[string]bool)
+	for _, netAddr := range def.MasterNetAddrs {
+		checkInterfaceMap[netAddr] = true
+	}
+
 	// maxHostIndex = 2^(host bits) - 1
 	maxHostIndex := int(math.Pow(2, float64(def.HostBlock)) - 1)
 
@@ -399,6 +405,11 @@ func (h *CIDRHandler) UpdateEntries(cidrSpec multinicv1.CIDRSpec, excludes []com
 		// assign interface index to each host
 		for _, iface := range ifaces {
 			interfaceNetAddress := iface.NetAddress
+			if len(def.MasterNetAddrs) > 0 {
+				if _, found := checkInterfaceMap[interfaceNetAddress]; !found {
+					continue
+				}
+			}
 			interfaceName := iface.InterfaceName
 			hostIP := iface.HostIP
 			success, entry := h.getInterfaceEntry(def, entriesMap, interfaceNetAddress)

--- a/unit-test/suite_test.go
+++ b/unit-test/suite_test.go
@@ -393,6 +393,7 @@ func getMultiNicCNINetwork(name string, cniVersion string, cniType string, cniAr
 				Type:       cniType,
 				CNIArgs:    cniArgs,
 			},
+			MasterNetAddrs: networkAddresses,
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes bug that cidr ignore specification of network address list. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>