### PR TITLE
change default namespace to multi-nic-cni-operator and prevent tabu concheck pod name

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Recommended to deploy in the same default namespace for [health check service](.
     ```
 
 #### Check connections
-##### Peer-to-peer - *quick test*
+##### One-time peer-to-peer - *quick test*
 1. Set target peer
    
     ```bash
@@ -168,7 +168,7 @@ Recommended to deploy in the same default namespace for [health check service](.
     # pod "multi-nic-iperf3-server" deleted
     ```
 
-##### All-to-all  - *recommended for small cluster (<10 HostInterfaces)*
+##### One-time all-to-all  - *recommended for small cluster (<10 HostInterfaces)*
 1. Run 
 
     ```bash
@@ -223,6 +223,9 @@ Recommended to deploy in the same default namespace for [health check service](.
    ```bash
     make clean-concheck
     ```
+##### Health checker service
+
+Deploy health check and agents to the cluster to serve a functional and connetion checking on-demand and periodically exporting to Prometheus metric server. See [more detail](./health-check/).
 
 #### Uninstallation
 1. Clean all CRs

--- a/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
+++ b/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
@@ -131,4 +131,4 @@ spec:
   provider:
     name: Foundation Model Stack
   version: 0.0.0
-  replaces: multi-nic-cni-operator.v1.1.0
+  replaces: multi-nic-cni-operator.v1.0.2

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -11,7 +11,7 @@ spec:
       value: "11000"
     - name: RT_TABLE_PATH
       value: /opt/rt_tables
-    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.0.2
+    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.0
     imagePullPolicy: Always
     mounts:
     - hostpath: /var/lib/cni/bin

--- a/connection-check/iperf3.go
+++ b/connection-check/iperf3.go
@@ -63,6 +63,10 @@ func (h *IperfHandler) getName(cidrName string, hostName string, labelValue stri
 	lengthOver := len(name) - MAX_NAME_LENGTH
 	if lengthOver > 0 {
 		name = name[lengthOver : len(name)-1]
+		// remove first character if it is hyphen
+		if name[0] == '-' {
+			name = name[1:len(name)]
+		}
 	}
 	return name
 }

--- a/controllers/vars/vars.go
+++ b/controllers/vars/vars.go
@@ -33,7 +33,7 @@ const (
 	DeamonLabelKey                            = "app"
 	DaemonLabelValue                          = "multi-nicd"
 	ServiceAccountName                        = "multi-nic-cni-operator-controller-manager"
-	DefaultOperatorNamespace                  = "multi-nic-cni-operator-system"
+	DefaultOperatorNamespace                  = "multi-nic-cni-operator"
 	DefaultCNIType                            = "multi-nic"
 	DefaultIPAMType                           = "multi-nic-ipam"
 	DefaultDaemonImage                        = "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.0"

--- a/deploy/0_deployment.yaml
+++ b/deploy/0_deployment.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: multi-nic-cni-operator-system
+  name: multi-nic-cni-operator
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1069,13 +1069,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: multi-nic-cni-operator-leader-election-role
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 rules:
 - apiGroups:
   - ""
@@ -1348,7 +1348,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: multi-nic-cni-operator-leader-election-rolebinding
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -1356,7 +1356,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1369,7 +1369,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1382,7 +1382,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1395,7 +1395,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1408,7 +1408,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1421,7 +1421,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1434,7 +1434,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: v1
 data:
@@ -1453,7 +1453,7 @@ data:
 kind: ConfigMap
 metadata:
   name: multi-nic-cni-operator-manager-config
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: v1
 kind: Service
@@ -1461,7 +1461,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: multi-nic-cni-operator-controller-manager-metrics-service
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 spec:
   ports:
   - name: https
@@ -1476,7 +1476,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 spec:
   replicas: 1
   selector:
@@ -1513,7 +1513,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-controller:v1.0.2
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-controller:v1.0.5
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/e2e-test/deploy/controller/deployment.yaml
+++ b/e2e-test/deploy/controller/deployment.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: multi-nic-cni-operator-system
+  name: multi-nic-cni-operator
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1069,13 +1069,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: multi-nic-cni-operator-leader-election-role
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 rules:
 - apiGroups:
   - ""
@@ -1348,7 +1348,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: multi-nic-cni-operator-leader-election-rolebinding
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -1356,7 +1356,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1369,7 +1369,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1382,7 +1382,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1395,7 +1395,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1408,7 +1408,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1421,7 +1421,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1434,7 +1434,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: v1
 data:
@@ -1453,7 +1453,7 @@ data:
 kind: ConfigMap
 metadata:
   name: multi-nic-cni-operator-manager-config
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: v1
 kind: Service
@@ -1461,7 +1461,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: multi-nic-cni-operator-controller-manager-metrics-service
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 spec:
   ports:
   - name: https
@@ -1476,7 +1476,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: multi-nic-cni-operator-controller-manager
-  namespace: multi-nic-cni-operator-system
+  namespace: multi-nic-cni-operator
 spec:
   replicas: 1
   selector:

--- a/e2e-test/script.sh
+++ b/e2e-test/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # yq 
 if [ -z ${OPERATOR_NAMESPACE} ]; then
-    OPERATOR_NAMESPACE="multi-nic-cni-operator-system"
+    OPERATOR_NAMESPACE="multi-nic-cni-operator"
 fi
 
 if [ -z ${DAEMON_STUB_IMG} ]; then

--- a/health-check/Makefile
+++ b/health-check/Makefile
@@ -4,6 +4,7 @@
 #
 
 export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
+export OPERATOR_NAMESPACE ?= multi-nic-cni-operator
 
 IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/multi-nic-cni
 IMAGE_VERSION ?= 1.0.0
@@ -36,7 +37,7 @@ test-checker: docker-build-checker
 	@docker run -i --privileged ${CHECKER_IMG} /bin/bash -c "make test"
 
 patch-sidecar:
-	@kubectl patch daemonset multi-nicd --type merge -n openshift-operators --patch-file ./sidecar/patch.yaml
+	@kubectl patch daemonset multi-nicd --type merge -patch-file ./sidecar/patch.yaml -n ${OPERATOR_NAMESPACE}
 
 deploy-agent:
 	@kubectl apply -f ./sidecar/manifest.yaml

--- a/health-check/README.md
+++ b/health-check/README.md
@@ -1,5 +1,12 @@
 # Multi-NIC CNI Health Check
 
+Default namespace is `multi-nic-cni-operator`. If the namespace is not created, please run
+
+```bash
+kubectl create ns multi-nic-cni-operator
+```
+
+
 ## Deployment Steps
 1. Set security policy to allow TCP communication on port `11001` on Host Primary Network 
 2. Clone this repository and move to health-check directory
@@ -36,7 +43,7 @@
 4. Check whether the health-checker and health-check-agent are running.
 
     ```bash
-    kubectl get po -n openshift-operators
+    kubectl get po -n multi-nic-cni-operator
     ```
 
     ```bash
@@ -50,8 +57,8 @@
 
     ```bash
     # forward port on one terminal
-    checker=$(kubectl get po -n openshift-operators|grep multi-nic-cni-health-checker|awk '{ print $1 }')
-    kubectl port-forward ${checker} -n openshift-operators 8080:8080
+    checker=$(kubectl get po -n multi-nic-cni-operator|grep multi-nic-cni-health-checker|awk '{ print $1 }')
+    kubectl port-forward ${checker} -n multi-nic-cni-operator 8080:8080
 
     # request the status check on another terminal. This request will activate the health check signal at the request time.
     curl localhost:8080/status

--- a/health-check/checker/deployment.yaml
+++ b/health-check/checker/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: multi-nic-cni-health-checker
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 spec:
   replicas: 1
   selector:
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: multi-nic-cni-health-checker-sa
       containers:
         - name: checker
-          image: ghcr.io/foundation-model-stack/multi-nic-cni-health-checker:v1.0.3
+          image: ghcr.io/foundation-model-stack/multi-nic-cni-health-checker:v1.0.5
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/health-check/checker/rbac.yaml
+++ b/health-check/checker/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multi-nic-cni-health-checker-sa
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -36,7 +36,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-health-checker-sa
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 roleRef:
   kind: ClusterRole
   name: multi-nic-cni-health-check
@@ -48,7 +48,7 @@ metadata:
   labels:
     multi-nic-cni-component: health-checker
   name: multi-nic-cni-health-check
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 spec:
   internalTrafficPolicy: Cluster
   ipFamilies:
@@ -79,7 +79,7 @@ spec:
       multi-nic-cni-component: health-checker
   namespaceSelector:
     matchNames:
-    - openshift-operators 
+    - multi-nic-cni-operator 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
   name: multi-nic-cni-health-check-prometheus
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 rules:
 - apiGroups:
   - ""
@@ -126,7 +126,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
   name: multi-nic-cni-health-check-prometheus
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/health-check/checker/script.sh
+++ b/health-check/checker/script.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ -z ${OPERATOR_NAMESPACE} ]; then
-    OPERATOR_NAMESPACE=openshift-operators
-fi
+# ./script.sh deploy or
+# ./script.sh deploy <network name>
 
+# get first name
 get_netname() {
-    kubectl get multinicnetwork -ojson|jq .items| jq -r '.[].metadata.name'
+    kubectl get multinicnetwork -ojson|jq .items| jq -r '.[].metadata.name'|head -n 1
 }
 
 apply() {

--- a/health-check/example-client/README.md
+++ b/health-check/example-client/README.md
@@ -7,8 +7,8 @@ To test locally, follow the steps below.
 1. forward checker port
 
     ```bash
-    checker=$(kubectl get po -n openshift-operators|grep multi-nic-cni-health-checker|awk '{ print $1 }')
-    kubectl port-forward ${checker} -n openshift-operators 8080:8080
+    checker=$(kubectl get po -n multi-nic-cni-operator|grep multi-nic-cni-health-checker|awk '{ print $1 }')
+    kubectl port-forward ${checker} -n multi-nic-cni-operator 8080:8080
     ```
 
 2. set local /status path, `CHECKER_URL`

--- a/health-check/example-client/read_status.py
+++ b/health-check/example-client/read_status.py
@@ -8,7 +8,7 @@ checker_namespace_env = "CHECKER_NAMESPACE"
 checker_path_fullname_env = "MULTI_NIC_HEALTH_CHECKER_ENDPOINT"
 checker_timeout_fullname_env = "MULTI_NIC_HEALTH_CHECKER_TIMEOUT"
 
-default_checker_namespace = "openshift-operators"
+default_checker_namespace = "multi-nic-cni-operator"
 default_timeout = "10" # seconds
 checker_service_name = "multi-nic-cni-health-check"
 service_port = 8080

--- a/health-check/sidecar/manifest.yaml
+++ b/health-check/sidecar/manifest.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multi-nic-cni-health-check-agent-sa
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -25,7 +25,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: multi-nic-cni-health-check-agent-sa
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 roleRef:
   kind: ClusterRole
   name: multi-nic-privileged-cr
@@ -35,7 +35,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: multi-nic-cni-health-agent
-  namespace: openshift-operators
+  namespace: multi-nic-cni-operator
 spec:
   selector:
     matchLabels:

--- a/health-check/sidecar/patch.yaml
+++ b/health-check/sidecar/patch.yaml
@@ -2,38 +2,11 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: multi-nicd
-  namespace: openshift-operators
 spec:
   template:
     spec:
       containers:
-      - env:
-        - name: DAEMON_PORT
-          value: "11000"
-        - name: RT_TABLE_PATH
-          value: /opt/rt_tables
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.0.3
-        imagePullPolicy: IfNotPresent
-        name: multi-nicd
-        ports:
-        - containerPort: 11000
-          hostPort: 11000
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cnibin
-        - mountPath: /var/lib/kubelet/device-plugins
-          name: device-plugin
-        - mountPath: /opt/rt_tables
-          name: rt-tables
+      - name: multi-nicd
       - env:
         - name: SIDECAR_PORT
           value: "11001"

--- a/live-migration/README.md
+++ b/live-migration/README.md
@@ -12,7 +12,7 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
     cd multi-nic-cni/live_migration
     chmod +x ./live_migrate.sh
     ```
-2. If operator is not installed in the `openshift-operators` namespace, run
+2. If operator is not installed in the `multi-nic-cni-operator` namespace, run
     ```bash
     export OPERATOR_NAMESPACE=<deployed-namespace>
     ```
@@ -135,8 +135,8 @@ To reinstall/upgrade multi-nic-cni-operator without affecting workloads running 
 
     ```
     # forward port on one terminal
-    checker=$(kubectl get po -n openshift-operators|grep multi-nic-cni-health-checker|awk '{ print $1 }')
-    kubectl port-forward ${checker} -n openshift-operators 8080:8080
+    checker=$(kubectl get po -n multi-nic-cni-operator|grep multi-nic-cni-health-checker|awk '{ print $1 }')
+    kubectl port-forward ${checker} -n multi-nic-cni-operator 8080:8080
 
     # request the status check on another terminal. This request will activate the health check signal at the request time.
     curl localhost:8080/status|jq

--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z ${OPERATOR_NAMESPACE} ]; then
-    OPERATOR_NAMESPACE=openshift-operators
+    OPERATOR_NAMESPACE=multi-nic-cni-operator
 fi
 
 if [ -z ${CLUSTER_NAME} ]; then
@@ -12,7 +12,7 @@ fi
 # utility functions
 
 get_netname() {
-    kubectl get multinicnetwork -ojson|jq .items| jq '.[].metadata.name'| tr -d '"'
+    kubectl get multinicnetwork -ojson|jq .items| jq '.[].metadata.name'| tr -d '"' | head -n 1
 }
 
 get_controller() {


### PR DESCRIPTION
This PR updates the default namespace to multi-nic-cni-operator instead of openshift-operators or multi-nic-cni-operator-system and prevent tabu concheck pod name by checking the hyphen start. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>