### PR TITLE
Fix unmanaged hif removed when daemon removed and no selection on unmanaged interfaces

### DIFF
--- a/controllers/daemon_watcher.go
+++ b/controllers/daemon_watcher.go
@@ -233,11 +233,15 @@ func (w *DaemonWatcher) ProcessPodQueue() {
 			}
 		} else {
 			vars.DaemonLog.V(4).Info(fmt.Sprintf("Daemon pod for %s deleted", nodeName))
-			// deleted, delete HostInterface
+
 			w.DaemonCacheHandler.SafeCache.UnsetCache(nodeName)
-			err := w.HostInterfaceHandler.DeleteHostInterface(nodeName)
-			if err != nil {
-				vars.DaemonLog.V(4).Info(fmt.Sprintf("Failed to delete HostInterface %s: %v", nodeName, err))
+			hif, err := w.HostInterfaceHandler.GetHostInterface(nodeName)
+			if err == nil && !vars.IsUnmanaged(hif.ObjectMeta) {
+				// deleted, delete HostInterface
+				err := w.HostInterfaceHandler.DeleteHostInterface(nodeName)
+				if err != nil {
+					vars.DaemonLog.V(4).Info(fmt.Sprintf("Failed to delete HostInterface %s: %v", nodeName, err))
+				}
 			}
 		}
 	}

--- a/daemon/src/backend/hostinterface.go
+++ b/daemon/src/backend/hostinterface.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package backend
+
+import (
+	"log"
+	"strings"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	HIF_RESOURCE = "hostinterfaces.v1.multinic.fms.io"
+	HIF_KIND     = "HostInterface"
+
+	UnmanagedLabelName = "multi-nic-unmanaged"
+)
+
+type InterfaceInfoType struct {
+	InterfaceName string `json:"interfaceName"`
+	NetAddress    string `json:"netAddress"`
+	HostIP        string `json:"hostIP"`
+	Vendor        string `json:"vendor"`
+	Product       string `json:"product"`
+	PciAddress    string `json:"pciAddress"`
+}
+
+type HostInterfaceSpec struct {
+	HostName   string              `json:"hostName"`
+	Interfaces []InterfaceInfoType `json:"interfaces"`
+}
+
+type HostInterfaceHandler struct {
+	*DynamicHandler
+	HostName string
+}
+
+func NewHostInterfaceHandler(config *rest.Config, hostName string) *HostInterfaceHandler {
+	dc, _ := discovery.NewDiscoveryClientForConfig(config)
+	dyn, _ := dynamic.NewForConfig(config)
+
+	handler := &HostInterfaceHandler{
+		DynamicHandler: &DynamicHandler{
+			DC:           dc,
+			DYN:          dyn,
+			ResourceName: HIF_RESOURCE,
+			Kind:         HIF_KIND,
+		},
+		HostName: hostName,
+	}
+	return handler
+}
+
+func (h *HostInterfaceHandler) IsUnmanaged(uobj unstructured.Unstructured) bool {
+	var metadata metav1.ObjectMeta
+	h.DynamicHandler.Parse(uobj.Object["metadata"].(map[string]interface{}), &metadata)
+	labels := metadata.Labels
+	unmanaged, found := labels[UnmanagedLabelName]
+	return found && (strings.ToLower(unmanaged) == "true")
+}
+
+func (h *HostInterfaceHandler) parse(uobj unstructured.Unstructured) HostInterfaceSpec {
+	var hifSpec HostInterfaceSpec
+	spec := uobj.Object["spec"].(map[string]interface{})
+	h.DynamicHandler.Parse(spec, &hifSpec)
+	return hifSpec
+}
+
+func (h *HostInterfaceHandler) GetInterfaces() ([]InterfaceInfoType, error) {
+	unstructuredHif, err := h.DynamicHandler.Get(h.HostName, metav1.NamespaceAll, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("Cannot get HostInterface %s", h.HostName)
+		return []InterfaceInfoType{}, err
+	}
+	if h.IsUnmanaged(*unstructuredHif) {
+		hif := h.parse(*unstructuredHif)
+		log.Printf("Get unmanaged HostInterface %s: %v", h.HostName, hif.Interfaces)
+		return hif.Interfaces, nil
+	}
+	// if not unmanaged, ignore the list
+	return []InterfaceInfoType{}, nil
+}

--- a/daemon/src/main.go
+++ b/daemon/src/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 type IPAMInfo struct {
-	HIFList []di.InterfaceInfoType `json:"hifs"`
+	HIFList []backend.InterfaceInfoType `json:"hifs"`
 }
 
 const (
@@ -248,6 +248,7 @@ func InitClient() *rest.Config {
 	ds.DeviceClassHandler = backend.NewDeviceClassHandler(config)
 	da.K8sClientset, _ = kubernetes.NewForConfig(config)
 	ds.K8sClientset, _ = kubernetes.NewForConfig(config)
+	di.HostInterfaceHandler = backend.NewHostInterfaceHandler(config, hostName)
 	return config
 
 }
@@ -266,8 +267,8 @@ func initHostName() {
 }
 
 func main() {
-	InitClient()
 	initHostName()
+	InitClient()
 	setDaemonPort, found := os.LookupEnv("DAEMON_PORT")
 	if found && setDaemonPort != "" {
 		setDaemonPortInt, err := strconv.Atoi(setDaemonPort)

--- a/daemon/src/main_test.go
+++ b/daemon/src/main_test.go
@@ -123,7 +123,7 @@ func setTestLatestInterfaces() {
 		vendor := MASTER_VENDORS[index]
 		product := MASTER_PRODUCTS[index]
 		pciAddress := MASTER_PCIADDRESS[index]
-		iface := di.InterfaceInfoType{
+		iface := backend.InterfaceInfoType{
 			InterfaceName: master,
 			NetAddress:    netAddress,
 			Vendor:        vendor,
@@ -190,6 +190,7 @@ var _ = BeforeSuite(func() {
 	ds.DeviceClassHandler = backend.NewDeviceClassHandler(cfg)
 	da.K8sClientset, _ = kubernetes.NewForConfig(cfg)
 	ds.K8sClientset, _ = kubernetes.NewForConfig(cfg)
+	di.HostInterfaceHandler = backend.NewHostInterfaceHandler(cfg, hostName)
 
 	deployExamples(EXAMPLE_RESOURCE_FOLDER, false)
 	addMasterInterfaces()
@@ -257,7 +258,7 @@ var _ = Describe("Test Get Interfaces", func() {
 		handler.ServeHTTP(res, req)
 		body, err := ioutil.ReadAll(res.Body)
 		Expect(err).NotTo(HaveOccurred())
-		var response []di.InterfaceInfoType
+		var response []backend.InterfaceInfoType
 		json.Unmarshal(body, &response)
 		log.Printf("TestUpdateInterface: %v", response)
 	})


### PR DESCRIPTION
This PR fixes two critical issues related to unmanaged host interfaces.
1. unmanaged HostInterface has been removed when daemon pod is removed. 
**Bug point:** in daemon watcher, it always remove hostinterface when daemon pod is deleted. 
2. No interface defined in unmanaged HostInterface selected by the daemon
**Bug point:** daemon is not aware of hostinterface resource. It get interfaces directly on the host.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>