### PR TITLE
ignore empty master name

### DIFF
--- a/daemon/src/selector/selector.go
+++ b/daemon/src/selector/selector.go
@@ -132,10 +132,11 @@ func Select(req NICSelectRequest) NICSelectResponse {
 	log.Printf("masterNets %v, %v, %v\n", selectedMasterNetAddrs, filteredMasterNameMap, nameNetMap)
 	for _, netAddress := range selectedMasterNetAddrs {
 		deviceID := deviceMap[netAddress]
-		master := filteredMasterNameMap[netAddress]
-		log.Printf("masterNets %s,%s\n", deviceID, master)
-		selectedDeviceIDs = append(selectedDeviceIDs, deviceID)
-		selectedMasters = append(selectedMasters, master)
+		if master, ok := filteredMasterNameMap[netAddress]; ok && master != "" {
+			log.Printf("masterNets %s,%s\n", deviceID, master)
+			selectedDeviceIDs = append(selectedDeviceIDs, deviceID)
+			selectedMasters = append(selectedMasters, master)
+		}
 	}
 
 	return NICSelectResponse{


### PR DESCRIPTION
This PR adds logic to remove empty master name from the return. 
This allows multi-nic CNI to ignore partial failure on some of device in the list. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>