### PR TITLE
fix CNI log and host-device delete

### DIFF
--- a/cni/plugins/main/multi-nic/host-device.go
+++ b/cni/plugins/main/multi-nic/host-device.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/utils"
 )
 
 const (
@@ -49,6 +50,7 @@ func loadHostDeviceConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*cu
 	// interfaces are orderly assigned from interface set
 	for index, deviceID := range n.DeviceIDs {
 		if deviceID == "" {
+			utils.Logger.Debug(fmt.Sprintf("skip %d: no device ID", index))
 			continue
 		}
 		// add config
@@ -70,7 +72,8 @@ func loadHostDeviceConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*cu
 		if n.IPAM.Type == HostDeviceIPAMType {
 			ipConfig := getHostIPConfig(index, n.Masters[index])
 			if ipConfig == nil {
-				continue
+				utils.Logger.Debug(fmt.Sprintf("skip %d: no host IP", index))
+				confBytes = replaceEmptyIPAM(confBytes)
 			}
 			confBytes = replaceMultiNicIPAM(confBytes, ipConfig)
 		} else if n.IsMultiNICIPAM {

--- a/cni/plugins/main/multi-nic/multi-nic.go
+++ b/cni/plugins/main/multi-nic/multi-nic.go
@@ -198,8 +198,10 @@ func cmdDel(args *skel.CmdArgs) error {
 	if n.IPAM.Type != "" {
 		injectedStdIn := injectMaster(args.StdinData, n.MasterNetAddrs, n.Masters, n.DeviceIDs)
 		if n.IPAM.Type != "multi-nic-ipam" {
-			err = ipam.ExecDel(n.IPAM.Type, injectedStdIn)
-			utils.Logger.Debug(fmt.Sprintf("Failed ipam.ExecDel %s: %v", err, string(injectedStdIn)))
+			if n.IPAM.Type != HostDeviceIPAMType {
+				err = ipam.ExecDel(n.IPAM.Type, injectedStdIn)
+				utils.Logger.Debug(fmt.Sprintf("Failed ipam.ExecDel %s: %v", err, string(injectedStdIn)))
+			}
 		} else {
 			r, err := ipam.ExecDelWithResult(n.IPAM.Type, injectedStdIn)
 			if err != nil {


### PR DESCRIPTION
This PR fixes the missing CNI log on host-device CNI call.
Also, replace nil with empty IP address when IP cannot be obtained from host interface for success interface deletion.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>