### PR TITLE
update sidecar version and add limit

### DIFF
--- a/health-check/sidecar/manifest.yaml
+++ b/health-check/sidecar/manifest.yaml
@@ -59,7 +59,7 @@ spec:
           valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-health-check-sidecar:v1.0.3
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-health-check-sidecar:v1.0.5
         imagePullPolicy: Always
         name: health-check-agent
         ports:
@@ -70,6 +70,9 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
This PR updates health check agent image version with the context timeout on plugin execution to avoid failed CNI. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>