### PR TITLE
reduce unnecessary update and add context deadline to API server call

### DIFF
--- a/controllers/cidr_handler.go
+++ b/controllers/cidr_handler.go
@@ -201,7 +201,9 @@ func (h *CIDRHandler) DeleteCIDR(cidr multinicv1.CIDR) error {
 	}
 	instance, err := h.GetCIDR(name)
 	if err == nil {
-		err = h.Client.Delete(context.Background(), instance)
+		ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+		defer cancel()
+		err = h.Client.Delete(ctx, instance)
 	}
 	if err != nil {
 		errorMsg = errorMsg + fmt.Sprintf("%v,", err)
@@ -525,14 +527,18 @@ func (h *CIDRHandler) updateCIDR(cidrSpec multinicv1.CIDRSpec, new bool) (bool, 
 		if err == nil {
 			updatedCIDR := existCIDR.DeepCopy()
 			updatedCIDR.Spec = spec
-			err = h.Client.Update(context.TODO(), updatedCIDR)
+			ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+			defer cancel()
+			err = h.Client.Update(ctx, updatedCIDR)
 			if err == nil {
 				h.SafeCache.SetCache(def.Name, updatedCIDR.Spec)
 			}
 			h.CleanPendingIPPools(ippoolSnapshot, def.Name, updatedCIDR.Spec)
 		} else {
 			if new {
-				err = h.Client.Create(context.TODO(), mapObj)
+				ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+				defer cancel()
+				err = h.Client.Create(ctx, mapObj)
 				if err == nil {
 					h.SafeCache.SetCache(def.Name, mapObj.Spec)
 				}

--- a/controllers/hostinterface_handler.go
+++ b/controllers/hostinterface_handler.go
@@ -61,7 +61,9 @@ func (h *HostInterfaceHandler) initHostInterface(hostName string, interfaces []m
 // CreateHostInterface creates new HostInterface from an interface list get from daemon pods
 func (h *HostInterfaceHandler) CreateHostInterface(hostName string, interfaces []multinicv1.InterfaceInfoType) error {
 	newHif := h.initHostInterface(hostName, interfaces)
-	return h.Client.Create(context.TODO(), newHif)
+	ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+	defer cancel()
+	return h.Client.Create(ctx, newHif)
 }
 
 // UpdateHostInterface updates HostInterface
@@ -73,7 +75,9 @@ func (h *HostInterfaceHandler) UpdateHostInterface(oldObj multinicv1.HostInterfa
 			Interfaces: interfaces,
 		},
 	}
-	return updateHif, h.Client.Update(context.TODO(), updateHif)
+	ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+	defer cancel()
+	return updateHif, h.Client.Update(ctx, updateHif)
 }
 
 // GetHostInterface gets HostInterface from hostname
@@ -83,7 +87,9 @@ func (h *HostInterfaceHandler) GetHostInterface(name string) (*multinicv1.HostIn
 		Name:      name,
 		Namespace: metav1.NamespaceAll,
 	}
-	err := h.Client.Get(context.TODO(), namespacedName, instance)
+	ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+	defer cancel()
+	err := h.Client.Get(ctx, namespacedName, instance)
 	return instance, err
 }
 
@@ -107,7 +113,9 @@ func (h *HostInterfaceHandler) ListHostInterface() (map[string]multinicv1.HostIn
 func (h *HostInterfaceHandler) DeleteHostInterface(name string) error {
 	instance, err := h.GetHostInterface(name)
 	if err == nil {
-		err = h.Client.Delete(context.TODO(), instance)
+		ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
+		defer cancel()
+		err = h.Client.Delete(ctx, instance)
 	}
 	return err
 }

--- a/daemon/src/backend/handler.go
+++ b/daemon/src/backend/handler.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	API_VERSION = "multinic.fms.io/v1"
+	API_VERSION       = "multinic.fms.io/v1"
+	APISERVER_TIMEOUT = 2 * time.Minute
 )
 
 type DynamicHandler struct {
@@ -71,7 +72,9 @@ func (h *DynamicHandler) Create(mapObj map[string]interface{}, namespace string,
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	log.Println(fmt.Sprintf("Create %s/%s", h.ResourceName, mapObj["metadata"].(map[string]interface{})["name"]))
 	start := time.Now()
-	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Create(context.TODO(), obj, options)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
+	defer cancel()
+	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Create(ctx, obj, options)
 	elapsed := time.Since(start)
 	log.Println(fmt.Sprintf("Create%s elapsed: %d us", h.Kind, int64(elapsed/time.Microsecond)))
 	return res, err
@@ -82,7 +85,9 @@ func (h *DynamicHandler) Update(mapObj map[string]interface{}, namespace string,
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	log.Println(fmt.Sprintf("Update %s/%s", h.ResourceName, mapObj["metadata"].(map[string]interface{})["name"]))
 	start := time.Now()
-	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Update(context.TODO(), obj, options)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
+	defer cancel()
+	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Update(ctx, obj, options)
 	elapsed := time.Since(start)
 	log.Println(fmt.Sprintf("Update%s elapsed: %d us", h.Kind, int64(elapsed/time.Microsecond)))
 	return res, err
@@ -91,7 +96,7 @@ func (h *DynamicHandler) Update(mapObj map[string]interface{}, namespace string,
 func (h *DynamicHandler) List(namespace string, options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
 	defer cancel()
 	res, err := h.DYN.Resource(*gvr).Namespace(namespace).List(ctx, options)
 	elapsed := time.Since(start)
@@ -102,7 +107,9 @@ func (h *DynamicHandler) List(namespace string, options metav1.ListOptions) (*un
 func (h *DynamicHandler) Get(name string, namespace string, options metav1.GetOptions) (*unstructured.Unstructured, error) {
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	start := time.Now()
-	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Get(context.TODO(), name, options)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
+	defer cancel()
+	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Get(ctx, name, options)
 	elapsed := time.Since(start)
 	log.Println(fmt.Sprintf("Get%s elapsed: %d us", h.Kind, int64(elapsed/time.Microsecond)))
 	return res, err
@@ -112,7 +119,9 @@ func (h *DynamicHandler) Delete(name string, namespace string, options metav1.De
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	log.Println(fmt.Sprintf("Delete %s/%s", h.ResourceName, name))
 	start := time.Now()
-	err := h.DYN.Resource(*gvr).Namespace(namespace).Delete(context.TODO(), name, options)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
+	defer cancel()
+	err := h.DYN.Resource(*gvr).Namespace(namespace).Delete(ctx, name, options)
 	elapsed := time.Since(start)
 	log.Println(fmt.Sprintf("Delete%s elapsed: %d us", h.Kind, int64(elapsed/time.Microsecond)))
 	return err
@@ -122,7 +131,9 @@ func (h *DynamicHandler) Patch(name string, namespace string, pt types.PatchType
 	gvr, _ := schema.ParseResourceArg(h.ResourceName)
 	log.Println(fmt.Sprintf("Patch %s/%s - %s", h.ResourceName, name, string(data)))
 	start := time.Now()
-	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Patch(context.TODO(), name, pt, data, options)
+	ctx, cancel := context.WithTimeout(context.Background(), APISERVER_TIMEOUT)
+	defer cancel()
+	res, err := h.DYN.Resource(*gvr).Namespace(namespace).Patch(ctx, name, pt, data, options)
 	elapsed := time.Since(start)
 	log.Println(fmt.Sprintf("Patch%s elapsed: %d us", h.Kind, int64(elapsed/time.Microsecond)))
 	return res, err

--- a/plugin/net_attach_def.go
+++ b/plugin/net_attach_def.go
@@ -108,6 +108,18 @@ func GetNetAttachDefHandler(config *rest.Config) (*NetAttachDefHandler, error) {
 	}, nil
 }
 
+func CheckDefChanged(def, existingDef *NetworkAttachmentDefinition) bool {
+	if def.Spec.Config != existingDef.Spec.Config || len(def.Annotations) != len(existingDef.Annotations) {
+		return true
+	}
+	for k, v := range existingDef.Annotations {
+		if def.Annotations[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
 // CreateOrUpdate creates new NetworkAttachmentDefinition resource if not exists, otherwise update
 func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pluginStr string, annotations map[string]string) error {
 	defs, err := h.generate(net, pluginStr, annotations)
@@ -122,9 +134,14 @@ func (h *NetAttachDefHandler) CreateOrUpdate(net *multinicv1.MultiNicNetwork, pl
 		if h.IsExist(name, namespace) {
 			existingDef, _ := h.Get(name, namespace)
 			def.ObjectMeta = existingDef.ObjectMeta
-			err := h.DynamicHandler.Update(namespace, def, result)
-			if err != nil {
-				errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
+			if CheckDefChanged(def, existingDef) {
+				if namespace == "default" {
+					vars.NetworkLog.V(2).Info(fmt.Sprintf("Update net-attach-def %s", def.Name))
+				}
+				err := h.DynamicHandler.Update(namespace, def, result)
+				if err != nil {
+					errMsg = fmt.Sprintf("%s\n%s: %v", errMsg, namespace, err)
+				}
 			}
 		} else {
 			err := h.DynamicHandler.Create(namespace, def, result)
@@ -159,6 +176,40 @@ func (h *NetAttachDefHandler) getNamespace(net *multinicv1.MultiNicNetwork) ([]s
 	return namespaces, nil
 }
 
+// NetToDef generates net-attach-def from multinicnetwork on specific namespace called by generate function
+func NetToDef(namespace string, net *multinicv1.MultiNicNetwork, pluginStr string, annotations map[string]string) (*NetworkAttachmentDefinition, error) {
+	name := net.GetName()
+	config := &NetConf{
+		NetConf: types.NetConf{
+			CNIVersion: CNI_VERSION,
+			Name:       name,
+			Type:       vars.TargetCNI,
+		},
+		Subnet:         net.Spec.Subnet,
+		MasterNetAddrs: net.Spec.MasterNetAddrs,
+		IsMultiNICIPAM: net.Spec.IsMultiNICIPAM,
+		DaemonPort:     vars.DaemonPort,
+	}
+	var ipamObj map[string]interface{}
+	configBytes, _ := json.Marshal(config)
+	configStr := string(configBytes)
+	err := json.Unmarshal([]byte(net.Spec.IPAM), &ipamObj)
+	if err != nil {
+		return nil, err
+	}
+	ipamBytes, _ := json.Marshal(ipamObj)
+	pluginValue := fmt.Sprintf("\"plugin\":%s", pluginStr)
+	ipamValue := fmt.Sprintf("\"ipam\":%s", string(ipamBytes))
+	configStr = strings.ReplaceAll(configStr, "\"ipam\":{}", ipamValue)
+	configStr = strings.ReplaceAll(configStr, "\"plugin\":null", pluginValue)
+	metaObj := GetMetaObject(name, namespace, annotations)
+	spec := NetworkAttachmentDefinitionSpec{
+		Config: configStr,
+	}
+	netattachdef := NewNetworkAttachmentDefinition(metaObj, spec)
+	return &netattachdef, nil
+}
+
 // generate initializes NetworkAttachmentDefinition objects from MultiNicNetwork and unmarshal plugin
 func (h *NetAttachDefHandler) generate(net *multinicv1.MultiNicNetwork, pluginStr string, annotations map[string]string) ([]*NetworkAttachmentDefinition, error) {
 	defs := []*NetworkAttachmentDefinition{}
@@ -168,37 +219,11 @@ func (h *NetAttachDefHandler) generate(net *multinicv1.MultiNicNetwork, pluginSt
 	}
 	vars.NetworkLog.V(2).Info(fmt.Sprintf("generate net-attach-def config on %d namespaces", len(namespaces)))
 	for _, ns := range namespaces {
-		name := net.GetName()
-		namespace := ns
-		config := &NetConf{
-			NetConf: types.NetConf{
-				CNIVersion: CNI_VERSION,
-				Name:       name,
-				Type:       vars.TargetCNI,
-			},
-			Subnet:         net.Spec.Subnet,
-			MasterNetAddrs: net.Spec.MasterNetAddrs,
-			IsMultiNICIPAM: net.Spec.IsMultiNICIPAM,
-			DaemonPort:     vars.DaemonPort,
-		}
-		var ipamObj map[string]interface{}
-		configBytes, _ := json.Marshal(config)
-		configStr := string(configBytes)
-		err := json.Unmarshal([]byte(net.Spec.IPAM), &ipamObj)
+		def, err := NetToDef(ns, net, pluginStr, annotations)
 		if err != nil {
 			return defs, err
 		}
-		ipamBytes, _ := json.Marshal(ipamObj)
-		pluginValue := fmt.Sprintf("\"plugin\":%s", pluginStr)
-		ipamValue := fmt.Sprintf("\"ipam\":%s", string(ipamBytes))
-		configStr = strings.ReplaceAll(configStr, "\"ipam\":{}", ipamValue)
-		configStr = strings.ReplaceAll(configStr, "\"plugin\":null", pluginValue)
-		metaObj := GetMetaObject(name, namespace, annotations)
-		spec := NetworkAttachmentDefinitionSpec{
-			Config: configStr,
-		}
-		netattachdef := NewNetworkAttachmentDefinition(metaObj, spec)
-		defs = append(defs, &netattachdef)
+		defs = append(defs, def)
 	}
 	return defs, nil
 }

--- a/unit-test/multinicnetwork_test.go
+++ b/unit-test/multinicnetwork_test.go
@@ -8,8 +8,12 @@ package controllers
 import (
 	"fmt"
 
+	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
+	"github.com/foundation-model-stack/multi-nic-cni/controllers"
+	"github.com/foundation-model-stack/multi-nic-cni/plugin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -31,5 +35,166 @@ var _ = Describe("Test deploying MultiNicNetwork", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = multinicnetworkReconciler.NetAttachDefHandler.DeleteNets(multinicnetwork)
 		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("Test definition changes check", func() {
+	cniVersion := "0.3.0"
+	cniType := "ipvlan"
+	mode := "l2"
+	mtu := 1500
+	cniArgs := make(map[string]string)
+	cniArgs["mode"] = mode
+	cniArgs["mtu"] = fmt.Sprintf("%d", mtu)
+
+	multinicnetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, cniArgs)
+	It("detect no change", func() {
+		mainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(multinicnetwork)
+		Expect(err).NotTo(HaveOccurred())
+		def, err := plugin.NetToDef("", multinicnetwork, mainPlugin, annotations)
+		Expect(err).NotTo(HaveOccurred())
+		defCopy, err := plugin.NetToDef("", multinicnetwork, mainPlugin, annotations)
+		Expect(err).NotTo(HaveOccurred())
+		changed := plugin.CheckDefChanged(defCopy, def)
+		Expect(changed).To(BeFalse())
+	})
+
+	It("detect annotation change", func() {
+		mainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(multinicnetwork)
+		Expect(err).NotTo(HaveOccurred())
+		def, err := plugin.NetToDef("", multinicnetwork, mainPlugin, annotations)
+		Expect(err).NotTo(HaveOccurred())
+
+		newAnnotations := map[string]string{"resource": "new"}
+		defWithNewAnnotation, err := plugin.NetToDef("", multinicnetwork, mainPlugin, newAnnotations)
+		Expect(err).NotTo(HaveOccurred())
+		changed := plugin.CheckDefChanged(defWithNewAnnotation, def)
+		Expect(changed).To(BeTrue())
+	})
+
+	It("detect config change", func() {
+		mainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(multinicnetwork)
+		Expect(err).NotTo(HaveOccurred())
+		def, err := plugin.NetToDef("", multinicnetwork, mainPlugin, annotations)
+		Expect(err).NotTo(HaveOccurred())
+
+		newCniArgs := make(map[string]string)
+		newCniArgs["mode"] = "l3"
+		newCniArgs["mtu"] = fmt.Sprintf("%d", mtu)
+		changedArgsNetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, newCniArgs)
+		newMainPlugin, annotations, err := multinicnetworkReconciler.GetMainPluginConf(changedArgsNetwork)
+		Expect(err).NotTo(HaveOccurred())
+		defWithNewArgs, err := plugin.NetToDef("", changedArgsNetwork, newMainPlugin, annotations)
+		Expect(err).NotTo(HaveOccurred())
+		changed := plugin.CheckDefChanged(defWithNewArgs, def)
+		Expect(changed).To(BeTrue())
+	})
+})
+
+func getNetStatus(computeResults []multinicv1.NicNetworkResult, discoverStatus multinicv1.DiscoverStatus, netConfigStatus multinicv1.NetConfigStatus, routeStatus multinicv1.RouteStatus) multinicv1.MultiNicNetworkStatus {
+	return multinicv1.MultiNicNetworkStatus{
+		ComputeResults:  computeResults,
+		DiscoverStatus:  discoverStatus,
+		NetConfigStatus: netConfigStatus,
+		RouteStatus:     routeStatus,
+		Message:         "",
+		LastSyncTime:    metav1.Now(),
+	}
+}
+
+func testNewNetStatus(multinicnetwork *multinicv1.MultiNicNetwork, newStatus multinicv1.MultiNicNetworkStatus, expectedChange bool) *multinicv1.MultiNicNetwork {
+	if expectedChange {
+		updated := controllers.NetStatusUpdated(multinicnetwork, newStatus)
+		// check new update
+		Expect(updated).To(Equal(expectedChange))
+		// update status
+		multinicnetwork.Status = newStatus
+	}
+	updated := controllers.NetStatusUpdated(multinicnetwork, newStatus)
+	// expect no update
+	Expect(updated).To(BeFalse())
+	return multinicnetwork
+}
+
+var _ = Describe("Test multinicnetwork status change check", func() {
+	cniVersion := "0.3.0"
+	cniType := "ipvlan"
+	mode := "l3"
+	mtu := 1500
+	cniArgs := make(map[string]string)
+	cniArgs["mode"] = mode
+	cniArgs["mtu"] = fmt.Sprintf("%d", mtu)
+
+	It("detect change from no status", func() {
+		multinicnetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, cniArgs)
+		initStatus := getNetStatus([]multinicv1.NicNetworkResult{}, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		updated := controllers.NetStatusUpdated(multinicnetwork, initStatus)
+		Expect(updated).To(BeTrue())
+	})
+
+	It("detect change on compute results", func() {
+		multinicnetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, cniArgs)
+		multinicnetwork.Status = getNetStatus([]multinicv1.NicNetworkResult{}, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+
+		net1 := multinicv1.NicNetworkResult{
+			NetAddress: "192.168.0.0/24",
+			NumOfHost:  1,
+		}
+		net2 := multinicv1.NicNetworkResult{
+			NetAddress: "192.168.1.0/24",
+			NumOfHost:  2,
+		}
+
+		computeResults := []multinicv1.NicNetworkResult{net1}
+		newStatus := getNetStatus(computeResults, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange := true
+		multinicnetwork = testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+
+		// add new compute result
+		computeResults = []multinicv1.NicNetworkResult{net1, net2}
+		newStatus = getNetStatus(computeResults, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange = true
+		multinicnetwork = testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+
+		// change order
+		computeResults = []multinicv1.NicNetworkResult{net2, net1}
+		newStatus = getNetStatus(computeResults, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange = false
+		multinicnetwork = testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+
+		// change values
+		net1.NetAddress = "192.168.0.2/24"
+		computeResults = []multinicv1.NicNetworkResult{net1, net2}
+		newStatus = getNetStatus(computeResults, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange = true
+		testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+		net1.NumOfHost = 3
+		computeResults = []multinicv1.NicNetworkResult{net1, net2}
+		newStatus = getNetStatus(computeResults, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange = true
+		testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+	})
+
+	It("detect change on simple status", func() {
+		multinicnetwork := getMultiNicCNINetwork("test-mn", cniVersion, cniType, cniArgs)
+		multinicnetwork.Status = getNetStatus([]multinicv1.NicNetworkResult{}, multinicv1.DiscoverStatus{}, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+
+		// change discover status
+		discoverStatus := multinicv1.DiscoverStatus{
+			ExistDaemon: 10,
+		}
+		newStatus := getNetStatus([]multinicv1.NicNetworkResult{}, discoverStatus, multinicv1.WaitForConfig, multinicv1.ApplyingRoute)
+		expectedChange := true
+		testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+
+		// change config status
+		newStatus = getNetStatus([]multinicv1.NicNetworkResult{}, discoverStatus, multinicv1.ConfigComplete, multinicv1.ApplyingRoute)
+		expectedChange = true
+		testNewNetStatus(multinicnetwork, newStatus, expectedChange)
+
+		// change route status
+		newStatus = getNetStatus([]multinicv1.NicNetworkResult{}, discoverStatus, multinicv1.ConfigComplete, multinicv1.AllRouteApplied)
+		expectedChange = true
+		testNewNetStatus(multinicnetwork, newStatus, expectedChange)
 	})
 })


### PR DESCRIPTION
This PR additionally reduces unnecessary multinicnetwork status and net-attach-def update with new functions of NetStatusUpdated and CheckDefChanged accordingly. 

Alos, this PR adds missing context deadline on API server call for both daemon and controller to prevent hang from non-responding API server.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com> 