### PR TITLE
add daemon server read/write timeout

### DIFF
--- a/daemon/src/main.go
+++ b/daemon/src/main.go
@@ -281,5 +281,11 @@ func main() {
 	router := handleRequests()
 	daemonAddress := fmt.Sprintf("0.0.0.0:%d", DAEMON_PORT)
 	log.Printf("Listening @%s", daemonAddress)
-	log.Fatal(http.ListenAndServe(daemonAddress, router))
+	srv := &http.Server{
+		Addr:         daemonAddress,
+		Handler:      router,
+		ReadTimeout:  10 * time.Minute,
+		WriteTimeout: 10 * time.Minute,
+	}
+	log.Fatal(srv.ListenAndServe())
 }


### PR DESCRIPTION
In addition to adding context deadline at client, we need to have resilient daemon server that has read/write timeout.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>