### PR TITLE
allow empty master if devices found on pod

### DIFF
--- a/cni/plugins/main/multi-nic/host-device.go
+++ b/cni/plugins/main/multi-nic/host-device.go
@@ -23,7 +23,7 @@ type HostDeviceTypeNetConf struct {
 	MainPlugin *HostDeviceNetConf `json:"plugin"`
 }
 
-type HostDeviceRuntimConfig struct {
+type HostDeviceRuntimeConfig struct {
 	DeviceID string `json:"deviceID,omitempty"`
 }
 
@@ -33,9 +33,9 @@ type HostDeviceNetConf struct {
 	Device        string `json:"device"` // Device-Name, something like eth0 or can0 etc.
 	HWAddr        string `json:"hwaddr"` // MAC Address of target network interface
 	DPDKMode      bool
-	KernelPath    string                 `json:"kernelpath"` // Kernelpath of the device
-	PCIAddr       string                 `json:"pciBusID"`   // PCI Address of target network device
-	RuntimeConfig HostDeviceRuntimConfig `json:"runtimeConfig,omitempty"`
+	KernelPath    string                  `json:"kernelpath"` // Kernelpath of the device
+	PCIAddr       string                  `json:"pciBusID"`   // PCI Address of target network device
+	RuntimeConfig HostDeviceRuntimeConfig `json:"runtimeConfig,omitempty"`
 }
 
 // loadHostDeviceConf unmarshal to HostDeviceNetConf and returns list of SR-IOV configs
@@ -62,7 +62,7 @@ func loadHostDeviceConf(bytes []byte, ifName string, n *NetConf, ipConfigs []*cu
 			singleConfig.CNIVersion = n.CNIVersion
 		}
 		singleConfig.Name = fmt.Sprintf("%s-%d", ifName, index)
-		singleConfig.RuntimeConfig = HostDeviceRuntimConfig{
+		singleConfig.RuntimeConfig = HostDeviceRuntimeConfig{
 			DeviceID: deviceID,
 		}
 		confBytes, err := json.Marshal(singleConfig)


### PR DESCRIPTION
This PR is an extension of previous PR https://github.com/foundation-model-stack/multi-nic-cni/pull/153  to prevent the issue when daemon pod has restarted during the job is running and cache has gone.

error:
```
zero config on cmdDel
```

As host-device deletion, there is no need of the master name. We add steps to assign the pod device IDs back to response when the daemon has no information of master device names. 

after this change:
- daemon return the device IDs with a list of empty master names
```
return: {[<device ID>] [ ]
```
- CNI can successfully execute the deletion
```
Exec DEL net1-0
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
