### PR TITLE
fix nil LastSyncTime and remove hostdevicenetwork handling

### DIFF
--- a/controllers/multinicnetwork_handler.go
+++ b/controllers/multinicnetwork_handler.go
@@ -161,6 +161,10 @@ func (h *MultiNicNetworkHandler) UpdateNetConfigStatus(instance *multinicv1.Mult
 		instance.Status.ComputeResults = []multinicv1.NicNetworkResult{}
 	}
 	instance.Status.NetConfigStatus = netConfigStatus
+	emptyTime := metav1.Time{}
+	if instance.Status.LastSyncTime == emptyTime {
+		instance.Status.LastSyncTime = metav1.Now()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), vars.ContextTimeout)
 	defer cancel()
 	err := h.Client.Status().Update(ctx, instance)

--- a/plugin/mellanox_resource.go
+++ b/plugin/mellanox_resource.go
@@ -27,17 +27,6 @@ const (
 	MELLANOX_POLICY_KIND  = "NicClusterPolicy"
 )
 
-func NewHostDeviceNetwork(metaObj metav1.ObjectMeta, spec HostDeviceNetworkSpec) HostDeviceNetwork {
-	return HostDeviceNetwork{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: MELLANOX_API_VERSION,
-			Kind:       MELLANOX_NETWORK_KIND,
-		},
-		ObjectMeta: metaObj,
-		Spec:       spec,
-	}
-}
-
 // ImageSpec Contains container image specifications
 type ImageSpec struct {
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\-]+
@@ -238,26 +227,4 @@ type NicClusterPolicy struct {
 
 	Spec   NicClusterPolicySpec   `json:"spec,omitempty"`
 	Status NicClusterPolicyStatus `json:"status,omitempty"`
-}
-
-// HostDeviceNetworkSpec defines the desired state of HostDeviceNetwork
-type HostDeviceNetworkSpec struct {
-	// Namespace of the NetworkAttachmentDefinition custom resource
-	NetworkNamespace string `json:"networkNamespace,omitempty"`
-	// Host device resource pool name
-	ResourceName string `json:"resourceName,omitempty"`
-	// IPAM configuration to be used for this network
-	IPAM string `json:"ipam,omitempty"`
-}
-
-type HostDeviceNetworkStatus struct {
-}
-
-// HostDeviceNetwork is the Schema for the hostdevicenetworks API
-type HostDeviceNetwork struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   HostDeviceNetworkSpec   `json:"spec,omitempty"`
-	Status HostDeviceNetworkStatus `json:"status,omitempty"`
 }

--- a/unit-test/plugin_test.go
+++ b/unit-test/plugin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/foundation-model-stack/multi-nic-cni/plugin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -159,16 +158,11 @@ var _ = Describe("Test GetConfig of main plugins", func() {
 		confBytes, annotations, err := mellanoxPlugin.GetConfig(*multinicnetwork, hifList)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(confBytes).NotTo(Equal(""))
-		netName := plugin.GetHolderNetName(multinicnetwork.Name)
-		resourceName := mellanoxPlugin.GetResourceName()
+		prefix, resourceName := mellanoxPlugin.GetResourceName()
 		Expect(resourceName)
-
-		hostDeviceNet := &plugin.HostDeviceNetwork{}
-		err = mellanoxPlugin.MellanoxNetworkHandler.Get(netName, metav1.NamespaceAll, hostDeviceNet)
-		// HostDeviceNetwork is created
-		Expect(err).NotTo(HaveOccurred())
-		Expect(hostDeviceNet.Spec.ResourceName).To(Equal(resourceName))
-		Expect(annotations[plugin.RESOURCE_ANNOTATION]).To(Equal(resourceName))
+		Expect(prefix)
+		fullName := prefix + "/" + resourceName
+		Expect(annotations[plugin.RESOURCE_ANNOTATION]).To(Equal(fullName))
 		err = mellanoxPlugin.CleanUp(*multinicnetwork)
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
There is no need to create HostDeviceNetwork custom resource.
To remove potential conflict on HostDeviceNetwork definition, we remove creation/deletion of HostDeviceNetwork from the configuration. 

Also, this PR fixed the nil issue on LastSyncTime value.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>