### PR TITLE
move to v1.2.3 and add namespace watcher

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -3,12 +3,12 @@ name: Build and push connection check image
 on:
   push:
     branches:
-      - v1.2.0
+      - v1.2.3
     paths:
       - connection-check/**
 
 env:
-  IMAGE_VERSION: '1.2.0'
+  IMAGE_VERSION: '1.2.3'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -3,7 +3,7 @@ name: Build and push controller and its bundle image
 on:
   push:
     branches:
-      - v1.2.0
+      - v1.2.3
     paths:
       - controllers/**
       - compute/**
@@ -16,7 +16,7 @@ on:
       - ./Makefile
 
 env:
-  VERSION: '1.2.0'
+  VERSION: '1.2.3'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -3,14 +3,14 @@ name: Build and push daemon image
 on:
   push:
     branches:
-      - v1.2.0
+      - v1.2.3
     paths:
       - daemon/**
       - cni/**
       - Makefile
       
 env:
-  IMAGE_VERSION: '1.2.0'
+  IMAGE_VERSION: '1.2.3'
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/daemon_unittest.yaml
+++ b/.github/workflows/daemon_unittest.yaml
@@ -3,7 +3,7 @@ name: Perform unittest for daemon
 on:
   pull_request:
     branches:
-      - v1.2.0
+      - v1.2.3
   push:
     paths:
       - daemon/**

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -3,7 +3,7 @@ name: e2e test
 on:
   pull_request:
     branches:
-      - v1.2.0
+      - v1.2.3
   push:
     paths:
       - controllers/**

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -3,7 +3,7 @@ name: Perform unittest for controller
 on:
   pull_request:
     branches:
-      - v1.2.0
+      - v1.2.3
   push:
     paths:
       - controllers/**

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # VERSION ?= 0.0.1
-VERSION ?= 1.2.0
+VERSION ?= 1.2.3
 export CHANNELS = "beta"
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Recommended to deploy in the same default namespace for [health check service](.
   ```
 ##### by bundle with operator-sdk
   ```bash
-  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.2.0 -n multi-nic-cni-operator
+  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.2.3 -n multi-nic-cni-operator
   ```
 #### Deploy MultiNicNetwork resource
 1. Prepare `network.yaml` as shown in the [example](#multinicnetwork)

--- a/api/v1/hostinterface_types.go
+++ b/api/v1/hostinterface_types.go
@@ -9,16 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 type InterfaceInfoType struct {
 	InterfaceName string `json:"interfaceName"`
-	NetAddress    string `json:"netAddress"`
-	HostIP        string `json:"hostIP"`
-	Vendor        string `json:"vendor"`
-	Product       string `json:"product"`
-	PciAddress    string `json:"pciAddress"`
+	NetAddress    string `json:"netAddress,omitempty"`
+	HostIP        string `json:"hostIP,omitempty"`
+	Vendor        string `json:"vendor,omitempty"`
+	Product       string `json:"product,omitempty"`
+	PciAddress    string `json:"pciAddress,omitempty"`
 }
 
 func (i InterfaceInfoType) Equal(cmp InterfaceInfoType) bool {

--- a/config/crd/bases/multinic.fms.io_hostinterfaces.yaml
+++ b/config/crd/bases/multinic.fms.io_hostinterfaces.yaml
@@ -54,12 +54,7 @@ spec:
                     vendor:
                       type: string
                   required:
-                  - hostIP
                   - interfaceName
-                  - netAddress
-                  - pciAddress
-                  - product
-                  - vendor
                   type: object
                 type: array
             required:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
-  newTag: v1.2.0
+  newTag: v1.2.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
+++ b/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
@@ -131,4 +131,4 @@ spec:
   provider:
     name: Foundation Model Stack
   version: 0.0.0
-  replaces: multi-nic-cni-operator.v1.1.0
+  replaces: multi-nic-cni-operator.v1.2.0

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -11,7 +11,7 @@ spec:
       value: "11000"
     - name: RT_TABLE_PATH
       value: /opt/rt_tables
-    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.0
+    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.3
     imagePullPolicy: Always
     mounts:
     - hostpath: /var/lib/cni/bin

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -15,4 +15,4 @@ kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
-  newTag: v1.2.0
+  newTag: v1.2.3

--- a/connection-check/concheck.yaml
+++ b/connection-check/concheck.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: multi-nic-concheck-account
       containers:
       - name: concheck
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.0
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.3
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/controllers/namespace_watcher.go
+++ b/controllers/namespace_watcher.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package controllers
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NamespaceWatcher watches new namespace and generate net-attach-def
+type NamespaceWatcher struct {
+	*kubernetes.Clientset
+	NamespaceQueue chan string
+	Quit           chan struct{}
+	*MultiNicNetworkReconciler
+}
+
+// NewNamespaceWatcher creates new namespace watcher
+func NewNamespaceWatcher(client client.Client, config *rest.Config, multinicnetworkReconciler *MultiNicNetworkReconciler, quit chan struct{}) *NamespaceWatcher {
+	clientset, _ := kubernetes.NewForConfig(config)
+	watcher := &NamespaceWatcher{
+		Clientset:                 clientset,
+		NamespaceQueue:            make(chan string),
+		Quit:                      quit,
+		MultiNicNetworkReconciler: multinicnetworkReconciler,
+	}
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	nsInformer := factory.Core().V1().Namespaces()
+
+	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if ns, ok := obj.(*v1.Namespace); ok {
+				watcher.NamespaceQueue <- ns.Name
+			}
+		},
+	})
+	factory.Start(watcher.Quit)
+
+	return watcher
+}
+
+// Run executes namespace watcher routine until get quit signal
+func (w *NamespaceWatcher) Run() {
+	defer close(w.NamespaceQueue)
+	wait.Until(w.ProcessNamespaceQueue, 0, w.Quit)
+}
+
+func (w *NamespaceWatcher) ProcessNamespaceQueue() {
+	ns := <-w.NamespaceQueue
+	w.MultiNicNetworkReconciler.HandleNewNamespace(ns)
+}

--- a/controllers/vars/vars.go
+++ b/controllers/vars/vars.go
@@ -77,6 +77,7 @@ var (
 
 	// logger options to change log level on the fly
 	ZapOpts    *zap.Options
+	SetupLog   logr.Logger
 	DaemonLog  logr.Logger
 	DefLog     logr.Logger
 	CIDRLog    logr.Logger
@@ -103,6 +104,7 @@ func SetLog() {
 	zapp := zap.New(zap.UseFlagOptions(ZapOpts))
 	dlog := logf.NewDelegatingLogSink(zapp.GetSink())
 	ctrl.Log = logr.New(dlog)
+	SetupLog = ctrl.Log.WithName("setup")
 	DaemonLog = ctrl.Log.WithName("controllers").WithName("Daemon")
 	DefLog = ctrl.Log.WithName("controllers").WithName("NetAttachDef")
 	CIDRLog = ctrl.Log.WithName("controllers").WithName("CIDR")

--- a/controllers/vars/vars.go
+++ b/controllers/vars/vars.go
@@ -36,7 +36,7 @@ const (
 	DefaultOperatorNamespace                  = "multi-nic-cni-operator"
 	DefaultCNIType                            = "multi-nic"
 	DefaultIPAMType                           = "multi-nic-ipam"
-	DefaultDaemonImage                        = "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.0"
+	DefaultDaemonImage                        = "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.3"
 	DefaultJoinPath                           = "/join"
 	DefaultInterfacePath                      = "/interface"
 	DefaultAddRoutePath                       = "/addl3"

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,7 +6,7 @@ export DAEMON_REGISTRY ?= ghcr.io/foundation-model-stack
 
 # DAEMON_IMG defines the image:tag used for daemon
 IMAGE_TAG_BASE = $(DAEMON_REGISTRY)/multi-nic-cni
-IMAGE_VERSION ?= 1.2.0
+IMAGE_VERSION ?= 1.2.3
 DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v$(IMAGE_VERSION)
 
 

--- a/daemon/dockerfiles/Dockerfile.kbuilder
+++ b/daemon/dockerfiles/Dockerfile.kbuilder
@@ -18,7 +18,7 @@ RUN curl -sSLo kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/k
 RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 
 RUN cd /tmp && \ 
-   git clone -b v1.2.0 https://github.com/containernetworking/plugins.git && \
+   git clone -b v1.2.3 https://github.com/containernetworking/plugins.git && \
 	 cd plugins && \
 	 ./build_linux.sh && \
 	 ls /tmp/plugins/bin && \


### PR DESCRIPTION
As a task of https://github.com/foundation-model-stack/multi-nic-cni/issues/183, this PR moves from v1.2.0 to v1.2.3.

This PR introduces namespace watcher to fix the issue as mentioned in https://github.com/foundation-model-stack/multi-nic-cni/issues/175.

In addition, we update the CRD of HostInterface to make its detail optional for future extension and set the default container of the controller pod to the manager container which will be useful for checking the log. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>