### PR TITLE
add namespace watcher to V1.3.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,6 +19,13 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8083"

--- a/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
+++ b/config/manifests/bases/multi-nic-cni-operator.clusterserviceversion.template
@@ -6,6 +6,16 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     containerImage: ${IMG}
+    repository: http://github.com/foundation-model-stack/multi-nic-cni
+    support: IBM
+    description: Automate container multi-network configuration
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   name: multi-nic-cni-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -131,4 +141,4 @@ spec:
   provider:
     name: Foundation Model Stack
   version: 0.0.0
-  replaces: multi-nic-cni-operator.v1.2.1
+  replaces: multi-nic-cni-operator.v1.2.2

--- a/controllers/multinicnetwork_handler.go
+++ b/controllers/multinicnetwork_handler.go
@@ -115,6 +115,7 @@ func (h *MultiNicNetworkHandler) updateStatus(instance *multinicv1.MultiNicNetwo
 
 	if !NetStatusUpdated(instance, netStatus) {
 		vars.NetworkLog.V(2).Info(fmt.Sprintf("No status update %s", instance.Name))
+		h.SetCache(instance.Name, *instance)
 		return netStatus, nil
 	}
 
@@ -126,7 +127,7 @@ func (h *MultiNicNetworkHandler) updateStatus(instance *multinicv1.MultiNicNetwo
 	if err != nil {
 		vars.NetworkLog.V(2).Info(fmt.Sprintf("Failed to update %s status: %v", instance.Name, err))
 	} else {
-		h.SetStatusCache(instance.Name, instance.Status)
+		h.SetCache(instance.Name, *instance)
 	}
 	return netStatus, err
 }
@@ -167,12 +168,12 @@ func (h *MultiNicNetworkHandler) UpdateNetConfigStatus(instance *multinicv1.Mult
 	if err != nil {
 		vars.NetworkLog.V(2).Info(fmt.Sprintf("Failed to update %s status: %v", instance.Name, err))
 	} else {
-		h.SetStatusCache(instance.Name, instance.Status)
+		h.SetCache(instance.Name, *instance)
 	}
 	return err
 }
 
-func (h *MultiNicNetworkHandler) SetStatusCache(key string, value multinicv1.MultiNicNetworkStatus) {
+func (h *MultiNicNetworkHandler) SetCache(key string, value multinicv1.MultiNicNetwork) {
 	h.SafeCache.SetCache(key, value)
 }
 
@@ -181,15 +182,40 @@ func (h *MultiNicNetworkHandler) GetStatusCache(key string) (multinicv1.MultiNic
 	if value == nil {
 		return multinicv1.MultiNicNetworkStatus{}, fmt.Errorf(vars.NotFoundError)
 	}
-	return value.(multinicv1.MultiNicNetworkStatus), nil
+	return value.(multinicv1.MultiNicNetwork).Status, nil
 }
 
 func (h *MultiNicNetworkHandler) ListStatusCache() map[string]multinicv1.MultiNicNetworkStatus {
 	snapshot := make(map[string]multinicv1.MultiNicNetworkStatus)
 	h.SafeCache.Lock()
 	for key, value := range h.cache {
-		snapshot[key] = value.(multinicv1.MultiNicNetworkStatus)
+		snapshot[key] = value.(multinicv1.MultiNicNetwork).Status
 	}
 	h.SafeCache.Unlock()
 	return snapshot
+}
+
+func (h *MultiNicNetworkHandler) FilterNetworksByNamespace(target string) []multinicv1.MultiNicNetwork {
+	filteredNetworks := []multinicv1.MultiNicNetwork{}
+	h.SafeCache.Lock()
+	for _, value := range h.cache {
+		net := value.(multinicv1.MultiNicNetwork)
+		namespaces := net.Spec.Namespaces
+		if len(namespaces) == 0 {
+			vars.NetworkLog.V(2).Info(fmt.Sprintf("FilterNetworksByNamespace %s has no namespace set", net.Name))
+			// NOTE: if namespace list is not specified, append
+			filteredNetworks = append(filteredNetworks, net)
+		} else {
+			vars.NetworkLog.V(2).Info(fmt.Sprintf("FilterNetworksByNamespace %s set %v", net.Name, namespaces))
+			// NOTE: if namespace list is specified and target is in the list, append
+			for _, ns := range namespaces {
+				if ns == target {
+					filteredNetworks = append(filteredNetworks, net)
+					break
+				}
+			}
+		}
+	}
+	h.SafeCache.Unlock()
+	return filteredNetworks
 }

--- a/controllers/namespace_watcher.go
+++ b/controllers/namespace_watcher.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package controllers
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NamespaceWatcher watches new namespace and generate net-attach-def
+type NamespaceWatcher struct {
+	*kubernetes.Clientset
+	NamespaceQueue chan string
+	Quit           chan struct{}
+	*MultiNicNetworkReconciler
+}
+
+// NewNamespaceWatcher creates new namespace watcher
+func NewNamespaceWatcher(client client.Client, config *rest.Config, multinicnetworkReconciler *MultiNicNetworkReconciler, quit chan struct{}) *NamespaceWatcher {
+	clientset, _ := kubernetes.NewForConfig(config)
+	watcher := &NamespaceWatcher{
+		Clientset:                 clientset,
+		NamespaceQueue:            make(chan string),
+		Quit:                      quit,
+		MultiNicNetworkReconciler: multinicnetworkReconciler,
+	}
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	nsInformer := factory.Core().V1().Namespaces()
+
+	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if ns, ok := obj.(*v1.Namespace); ok {
+				watcher.NamespaceQueue <- ns.Name
+			}
+		},
+	})
+	factory.Start(watcher.Quit)
+
+	return watcher
+}
+
+// Run executes namespace watcher routine until get quit signal
+func (w *NamespaceWatcher) Run() {
+	defer close(w.NamespaceQueue)
+	wait.Until(w.ProcessNamespaceQueue, 0, w.Quit)
+}
+
+func (w *NamespaceWatcher) ProcessNamespaceQueue() {
+	ns := <-w.NamespaceQueue
+	w.MultiNicNetworkReconciler.HandleNewNamespace(ns)
+}

--- a/controllers/vars/vars.go
+++ b/controllers/vars/vars.go
@@ -80,6 +80,7 @@ var (
 
 	// logger options to change log level on the fly
 	ZapOpts    *zap.Options
+	SetupLog   logr.Logger
 	DaemonLog  logr.Logger
 	DefLog     logr.Logger
 	CIDRLog    logr.Logger
@@ -106,6 +107,7 @@ func SetLog() {
 	zapp := zap.New(zap.UseFlagOptions(ZapOpts))
 	dlog := logf.NewDelegatingLogSink(zapp.GetSink())
 	ctrl.Log = logr.New(dlog)
+	SetupLog = ctrl.Log.WithName("setup")
 	DaemonLog = ctrl.Log.WithName("controllers").WithName("Daemon")
 	DefLog = ctrl.Log.WithName("controllers").WithName("NetAttachDef")
 	CIDRLog = ctrl.Log.WithName("controllers").WithName("CIDR")


### PR DESCRIPTION
This PR updates namespace watcher patch to v1.3.0 (based from v1.2.2).

Additionally, this PR also update missing fields and resource limit/request which will be tested by static preflight and update the replaces field for alpha channel.   

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>