### PR TITLE
fix: ignore built-in ipam on cmdDel

### DIFF
--- a/cni/plugins/main/multi-nic/multi-nic.go
+++ b/cni/plugins/main/multi-nic/multi-nic.go
@@ -112,7 +112,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 		// Invoke ipam del if err to avoid ip leak
 		defer func() {
 			if err != nil {
-				ipam.ExecDel(n.IPAM.Type, args.StdinData)
+				if !isBuiltInIPAM(n.IPAM.Type) {
+					ipam.ExecDel(n.IPAM.Type, args.StdinData)
+				}
 			}
 		}()
 
@@ -233,7 +235,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 	utils.Logger.Debug(fmt.Sprintf("Received an DEL request for: conf=%v", n))
 	// On chained invocation, IPAM block can be empty
-	if n.IPAM.Type != "" {
+	if n.IPAM.Type != "" && !isBuiltInIPAM(n.IPAM.Type) {
 		injectedStdIn := injectMaster(args.StdinData, n.MasterNetAddrs, n.Masters, n.DeviceIDs)
 		if n.IPAM.Type != "multi-nic-ipam" {
 			err = ipam.ExecDel(n.IPAM.Type, injectedStdIn)

--- a/cni/plugins/main/multi-nic/utils.go
+++ b/cni/plugins/main/multi-nic/utils.go
@@ -227,3 +227,8 @@ func getHostIPConfig(index int, devName string) *current.IPConfig {
 	}
 	return ipConf
 }
+
+// isBuiltInIPAM returns true if ipam is a built-in IPAM (host-device-ipam)
+func isBuiltInIPAM(ipamType string) bool {
+	return ipamType == HostDeviceIPAMType
+}


### PR DESCRIPTION
This PR adds `isBuiltInIPAM ` to check whether IPAM is built-in function before calling Exec. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>