### PR TITLE
chore: increase version to 1.2.4

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -3,12 +3,12 @@ name: Build and push connection check image
 on:
   push:
     branches:
-      - v1.2.3
+      - v1.2.4
     paths:
       - connection-check/**
 
 env:
-  IMAGE_VERSION: '1.2.3'
+  IMAGE_VERSION: '1.2.4'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -3,7 +3,7 @@ name: Build and push controller and its bundle image
 on:
   push:
     branches:
-      - v1.2.3
+      - v1.2.4
     paths:
       - controllers/**
       - compute/**
@@ -16,7 +16,7 @@ on:
       - ./Makefile
 
 env:
-  VERSION: '1.2.3'
+  VERSION: '1.2.4'
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -3,14 +3,14 @@ name: Build and push daemon image
 on:
   push:
     branches:
-      - v1.2.3
+      - v1.2.4
     paths:
       - daemon/**
       - cni/**
       - Makefile
       
 env:
-  IMAGE_VERSION: '1.2.3'
+  IMAGE_VERSION: '1.2.4'
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/daemon_unittest.yaml
+++ b/.github/workflows/daemon_unittest.yaml
@@ -3,7 +3,7 @@ name: Perform unittest for daemon
 on:
   pull_request:
     branches:
-      - v1.2.3
+      - v1.2.4
   push:
     paths:
       - daemon/**

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+env:
+  GOLANGCI_LINT_VERSION: v1.54.2
+
 jobs:
   golangci:
     name: lint
@@ -19,3 +22,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=10m
+          version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -3,7 +3,7 @@ name: e2e test
 on:
   pull_request:
     branches:
-      - v1.2.3
+      - v1.2.4
   push:
     paths:
       - controllers/**

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -3,7 +3,7 @@ name: Perform unittest for controller
 on:
   pull_request:
     branches:
-      - v1.2.3
+      - v1.2.4
   push:
     paths:
       - controllers/**

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # VERSION ?= 0.0.1
-VERSION ?= 1.2.3
+VERSION ?= 1.2.4
 export CHANNELS = "beta"
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,10 @@
 #
 include daemon/Makefile
 
+DOCKER ?= $(shell command -v podman 2> /dev/null || echo docker)
+
 export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
-ifneq ($(shell kubectl get po -A --selector app=multus --ignore-not-found),)
-export CNI_BIN_HOSTPATH = $(shell kubectl get po -A --selector app=multus -o jsonpath='{.items[0].spec.volumes[?(@.name=="cnibin")].hostPath.path}')
-else
-export CNI_BIN_HOSTPATH = /var/lib/cni/bin
-endif
+
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -114,18 +112,18 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 golint:
-	docker pull golangci/golangci-lint:latest
-	docker run --tty --rm \
+	$(DOCKER) pull golangci/golangci-lint:v1.54.2
+	$(DOCKER) run --tty --rm \
 		--volume '$(BASE_DIR):/app' \
 		--workdir /app \
-		golangci/golangci-lint \
+		golangci/golangci-lint:v1.54.2 \
 		golangci-lint run --verbose
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	$(DOCKER) build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(DOCKER) push ${IMG}
 
 ##@ Deployment
 
@@ -163,8 +161,8 @@ daemon-secret: ## Modify kustomization files for image pull secret of daemon
 	envsubst < config/samples/patches/image_pull_secret.template > config/samples/patches/image_pull_secret.yaml
 	cd config/samples;$(KUSTOMIZE) edit add patch --path patches/image_pull_secret.yaml
 
-concheck: 
-	@kubectl create -f connection-check/concheck.yaml 
+concheck:
+	@kubectl create -f connection-check/concheck.yaml
 	@echo "Wait for job/multi-nic-concheck to complete"
 	@kubectl wait --for=condition=complete job/multi-nic-concheck --timeout=3000s
 	@kubectl logs job/multi-nic-concheck
@@ -174,11 +172,10 @@ clean-concheck:
 	@kubectl delete pod -n default --selector multi-nic-concheck
 	@kubectl delete job -n default --selector multi-nic-concheck
 
-
-export SERVER_HOST_NAME ?= $(shell kubectl get nodes|tail -n 2|head -n 1|awk '{ print $1 }')
-export CLIENT_HOST_NAME ?= $(shell kubectl get nodes|tail -n 1|awk '{ print $1 }')
 sample-concheck:
-	@echo "Test connection from ${CLIENT_HOST_NAME} to ${SERVER_HOST_NAME}"
+	@export SERVER_HOST_NAME ?= $(shell kubectl get nodes|tail -n 2|head -n 1|awk '{ print $1 }')
+	@export CLIENT_HOST_NAME ?= $(shell kubectl get nodes|tail -n 1|awk '{ print $1 }')
+	@echo "Test connection from ${CLIENT_HOST_NAME} to ${SERVER_HOST_NAME}"ƒ
 	@cd ./live-migration && chmod +x live_migrate.sh && ./live_migrate.sh live_iperf3 ${SERVER_HOST_NAME} ${CLIENT_HOST_NAME} 5
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
@@ -264,16 +261,16 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 test-daemon:
-	docker build -t daemon-test:latest -f ./daemon/dockerfiles/Dockerfile.multi-nicd-test .
-	docker run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/cni&&make test"
-	docker run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"
+	$(DOCKER) build -t daemon-test:latest -f ./daemon/dockerfiles/Dockerfile.multi-nicd-test .
+	$(DOCKER) run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/cni&&make test"
+	$(DOCKER) run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"
 
 build-push-kbuilder-base:
-	docker build -t $(IMAGE_TAG_BASE)-kbuilder -f ./daemon/dockerfiles/Dockerfile.kbuilder .
-	docker push $(IMAGE_TAG_BASE)-kbuilder
+	$(DOCKER) build -t $(IMAGE_TAG_BASE)-kbuilder -f ./daemon/dockerfiles/Dockerfile.kbuilder .
+	$(DOCKER) push $(IMAGE_TAG_BASE)-kbuilder
 
 daemon-build: test-daemon ## Build docker image with the manager.
-	docker tag daemon-test:latest $(IMAGE_TAG_BASE)-daemon:v$(VERSION)
+	$(DOCKER) tag daemon-test:latest $(IMAGE_TAG_BASE)-daemon:v$(VERSION)
 
 daemon-push:
-	docker push $(IMAGE_TAG_BASE)-daemon:v$(VERSION)
+	$(DOCKER) push $(IMAGE_TAG_BASE)-daemon:v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Recommended to deploy in the same default namespace for [health check service](.
   ```
 ##### by bundle with operator-sdk
   ```bash
-  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.2.3 -n multi-nic-cni-operator
+  operator-sdk run bundle ghcr.io/foundation-model-stack/multi-nic-cni-bundle:v1.2.4 -n multi-nic-cni-operator
   ```
 #### Deploy MultiNicNetwork resource
 1. Prepare `network.yaml` as shown in the [example](#multinicnetwork)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
-  newTag: v1.2.3
+  newTag: v1.2.4

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -11,7 +11,7 @@ spec:
       value: "11000"
     - name: RT_TABLE_PATH
       value: /opt/rt_tables
-    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.3
+    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.4
     imagePullPolicy: Always
     mounts:
     - hostpath: /var/lib/cni/bin

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -15,4 +15,4 @@ kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
-  newTag: v1.2.3
+  newTag: v1.2.4

--- a/connection-check/concheck.yaml
+++ b/connection-check/concheck.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: multi-nic-concheck-account
       containers:
       - name: concheck
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.3
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.4
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,7 +6,7 @@ export DAEMON_REGISTRY ?= ghcr.io/foundation-model-stack
 
 # DAEMON_IMG defines the image:tag used for daemon
 IMAGE_TAG_BASE = $(DAEMON_REGISTRY)/multi-nic-cni
-IMAGE_VERSION ?= 1.2.3
+IMAGE_VERSION ?= 1.2.4
 DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v$(IMAGE_VERSION)
 
 

--- a/daemon/dockerfiles/Dockerfile.kbuilder
+++ b/daemon/dockerfiles/Dockerfile.kbuilder
@@ -18,7 +18,7 @@ RUN curl -sSLo kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/k
 RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 
 RUN cd /tmp && \ 
-   git clone -b v1.2.3 https://github.com/containernetworking/plugins.git && \
+   git clone -b v1.2.4 https://github.com/containernetworking/plugins.git && \
 	 cd plugins && \
 	 ./build_linux.sh && \
 	 ls /tmp/plugins/bin && \


### PR DESCRIPTION
This PR includes the following changes:
- update version to 1.2.4
- update Makefile by moving kubectl command under target (allow running with k8s cluster)
- update Makefile to allow podman usage
- fix golint version (this is a temporary change until we update the code to align with the latest lint to mitigate ci error issue). opened an issue: https://github.com/foundation-model-stack/multi-nic-cni/issues/201