### PR TITLE
feat: keep missing dev but not select

### DIFF
--- a/controllers/daemon_watcher.go
+++ b/controllers/daemon_watcher.go
@@ -233,11 +233,14 @@ func (w *DaemonWatcher) ProcessPodQueue() {
 			}
 		} else {
 			vars.DaemonLog.V(4).Info(fmt.Sprintf("Daemon pod for %s deleted", nodeName))
-			// deleted, delete HostInterface
-			w.DaemonCacheHandler.SafeCache.UnsetCache(nodeName)
-			err := w.HostInterfaceHandler.DeleteHostInterface(nodeName)
-			if err != nil {
-				vars.DaemonLog.V(4).Info(fmt.Sprintf("Failed to delete HostInterface %s: %v", nodeName, err))
+			_, err := w.Clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			if errors.IsNotFound(err) {
+				// deleted, delete HostInterface
+				w.DaemonCacheHandler.SafeCache.UnsetCache(nodeName)
+				err := w.HostInterfaceHandler.DeleteHostInterface(nodeName)
+				if err != nil {
+					vars.DaemonLog.V(4).Info(fmt.Sprintf("Failed to delete HostInterface %s: %v", nodeName, err))
+				}
 			}
 		}
 	}

--- a/daemon/src/backend/hostinterface.go
+++ b/daemon/src/backend/hostinterface.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package backend
+
+import (
+	"github.com/foundation-model-stack/multi-nic-cni/daemon/iface"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	HOSTINTERFACE_RESOURCE = "hostinterfaces.v1.multinic.fms.io"
+	HOSTINTERFACE_KIND     = "hostinterfaces"
+)
+
+type HostInterfaceHandler struct {
+	*DynamicHandler
+	hostName string
+}
+
+func NewHostInterfaceHandler(config *rest.Config, hostName string) *HostInterfaceHandler {
+	dc, _ := discovery.NewDiscoveryClientForConfig(config)
+	dyn, _ := dynamic.NewForConfig(config)
+
+	handler := &HostInterfaceHandler{
+		hostName: hostName,
+		DynamicHandler: &DynamicHandler{
+			DC:           dc,
+			DYN:          dyn,
+			ResourceName: HOSTINTERFACE_RESOURCE,
+			Kind:         HOSTINTERFACE_KIND,
+		},
+	}
+	return handler
+}
+
+func (h *HostInterfaceHandler) parse(uobj *unstructured.Unstructured) ([]iface.InterfaceInfoType, error) {
+	var infos []iface.InterfaceInfoType
+	var err error
+	spec := uobj.Object["spec"].(map[string]interface{})
+	if v, found := spec["interfaces"]; found {
+		if vals, ok := v.([]interface{}); ok {
+			for _, v := range vals {
+				var info iface.InterfaceInfoType
+				h.DynamicHandler.Parse(v.(map[string]interface{}), &info)
+				infos = append(infos, info)
+			}
+		} else {
+			err = fmt.Errorf("cannot parse value of interfaces")
+		}
+	} else {
+		err = fmt.Errorf("`interfaces` field not found")
+	}
+	return infos, err
+}
+
+func (h *HostInterfaceHandler) GetHostInterfaces() ([]iface.InterfaceInfoType, error) {
+	hifobj, err := h.DynamicHandler.Get(h.hostName, metav1.NamespaceAll, metav1.GetOptions{})
+	if err == nil {
+		infos, err := h.parse(hifobj)
+		return infos, err
+	}
+	return []iface.InterfaceInfoType{}, err
+}

--- a/daemon/src/iface/iface.go
+++ b/daemon/src/iface/iface.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -189,4 +190,12 @@ func getNetAddressFromDevice(devName string) (string, error) {
 	}
 	netAddress := getNetAddress(addr)
 	return netAddress, nil
+}
+
+func DeviceExists(devName string) bool {
+	if val, ok := os.LookupEnv("TEST_MODE"); ok && val == "true" {
+		return true
+	}
+	_, err := netlink.LinkByName(devName)
+	return err == nil
 }

--- a/daemon/src/iface/pci.go
+++ b/daemon/src/iface/pci.go
@@ -54,6 +54,14 @@ type NetDeviceInfo struct {
 	PciAddress string
 }
 
+func SetDeviceMapCache(pciAddresss, name string) {
+	deviceMapCache.SetCache(pciAddresss, name)
+}
+
+func GetDeviceMapSize() int {
+	return deviceMapCache.GetSize()
+}
+
 func getCheckpointData() (checkpointData, error) {
 	cpd := &checkpointFileData{}
 	rawBytes, err := os.ReadFile(CheckPointfile)

--- a/daemon/src/main.go
+++ b/daemon/src/main.go
@@ -271,7 +271,7 @@ func initHostName() {
 }
 
 func main() {
-	InitClient()
+	cfg := InitClient()
 	initHostName()
 	setDaemonPort, found := os.LookupEnv("DAEMON_PORT")
 	if found && setDaemonPort != "" {
@@ -281,7 +281,7 @@ func main() {
 		}
 	}
 	dr.SetRTTablePath()
-
+	ds.InitCache(cfg, hostName)
 	da.CleanHangingAllocation(hostName)
 	router := handleRequests()
 	daemonAddress := fmt.Sprintf("0.0.0.0:%d", DAEMON_PORT)

--- a/daemon/src/main_test.go
+++ b/daemon/src/main_test.go
@@ -9,16 +9,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	da "github.com/foundation-model-stack/multi-nic-cni/daemon/allocator"
 	backend "github.com/foundation-model-stack/multi-nic-cni/daemon/backend"
 	di "github.com/foundation-model-stack/multi-nic-cni/daemon/iface"
 	dr "github.com/foundation-model-stack/multi-nic-cni/daemon/router"
 	ds "github.com/foundation-model-stack/multi-nic-cni/daemon/selector"
-	"io/ioutil"
 	"k8s.io/client-go/kubernetes"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
@@ -32,19 +33,21 @@ import (
 	"k8s.io/client-go/restmapper"
 
 	"context"
+	"path/filepath"
+
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/runtime"
-	"path/filepath"
+
+	"log"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"strings"
 
 	"os"
 	//+kubebuilder:scaffold:imports
@@ -156,6 +159,7 @@ func replacePodUID(clientset *kubernetes.Clientset) {
 }
 
 var _ = BeforeSuite(func() {
+	os.Setenv("TEST_MODE", "true")
 
 	// this env should be set by config.multinic when creating the daemonset
 	os.Setenv(NODENAME_ENV, FULL_HOST_NAME)

--- a/unit-test/hostinterface_test.go
+++ b/unit-test/hostinterface_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package controllers
+
+import (
+	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
+	"github.com/foundation-model-stack/multi-nic-cni/controllers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Host Interface Test", func() {
+	Context("UpdateNewInterfaces - original with a single device", func() {
+		origInfos := []multinicv1.InterfaceInfoType{
+			genInterfaceInfo("eth1", "10.0.0.0/24"),
+		}
+		It("can detect change", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth1", "10.0.1.0/24"),
+			}
+			newInfos, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeTrue())
+			Expect(len(newInfos)).To(Equal(1))
+			Expect(newInfos[0].InterfaceName).To(Equal("eth1"))
+			Expect(newInfos[0].NetAddress).To(Equal("10.0.1.0/24"))
+		})
+		It("can check no change", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth1", "10.0.0.0/24"),
+			}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can leave old one", func() {
+			newInfos := []multinicv1.InterfaceInfoType{}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can add new while leave old one", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth2", "10.0.1.0/24"),
+			}
+			newInfos, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeTrue())
+			Expect(len(newInfos)).To(Equal(2))
+			for _, newInfo := range newInfos {
+				Expect(newInfo.InterfaceName).To(BeElementOf("eth1", "eth2"))
+				Expect(newInfo.NetAddress).To(BeElementOf("10.0.0.0/24", "10.0.1.0/24"))
+			}
+		})
+	})
+	Context("UpdateNewInterfaces - original with more than one devices", func() {
+		origInfos := []multinicv1.InterfaceInfoType{
+			genInterfaceInfo("eth1", "10.0.0.0/24"),
+			genInterfaceInfo("eth2", "10.0.1.0/24"),
+		}
+		It("can leave old one", func() {
+			newInfos := []multinicv1.InterfaceInfoType{}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can check no change", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth1", "10.0.0.0/24"),
+				genInterfaceInfo("eth2", "10.0.1.0/24"),
+			}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can check no change in swop order", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth2", "10.0.1.0/24"),
+				genInterfaceInfo("eth1", "10.0.0.0/24"),
+			}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can leave old one when some is missing", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth1", "10.0.0.0/24"),
+			}
+			_, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeFalse())
+		})
+		It("can leave old one when some is missing and some with new info", func() {
+			newInfos := []multinicv1.InterfaceInfoType{
+				genInterfaceInfo("eth1", "10.0.2.0/24"),
+			}
+			newInfos, updated := controllers.UpdateNewInterfaces(origInfos, newInfos)
+			Expect(updated).To(BeTrue())
+			Expect(len(newInfos)).To(Equal(2))
+			for _, newInfo := range newInfos {
+				Expect(newInfo.InterfaceName).To(BeElementOf("eth1", "eth2"))
+				Expect(newInfo.NetAddress).To(BeElementOf("10.0.2.0/24", "10.0.1.0/24"))
+			}
+		})
+	})
+
+})
+
+func genInterfaceInfo(devName, netAddress string) multinicv1.InterfaceInfoType {
+	return multinicv1.InterfaceInfoType{
+		InterfaceName: devName,
+		NetAddress:    netAddress,
+	}
+}


### PR DESCRIPTION
This PR is to fix https://github.com/foundation-model-stack/multi-nic-cni/issues/206.

### change summary
#### controller
- replace function `interfaceChanged ` with `UpdateNewInterfaces` to keep old interface info even if the device does not exist anymore. replace old information with new information using the interface name as a primary key to determine updated item.
- do not delete HostInterface even if the node is still alive even if the daemon pod is deleted.
####  daemon
- check device exist before putting in the selected list (for policy-based selection) except the TEST_MODE is set
- introduce function `InitCache` to read HostInterface at the beginning to fetch the existing information


### testing
- add unit test for `UpdateNewInterfaces`
- test the following scenario in the real cluster
1. deploy workload pod
2. delete multi-nicd pod and wait until it is recreated
3. delete workload pod

The log from the multi-nicd pod shows that it can first set the cache and can return corresponding list of interface names on deletion.
```
2025/01/09 04:23:27 set 32 devices cache from hostinterface CR
...
2025/01/09 04:26:13 return: {[(pciAddress values)] [(interface name values)]}
```
