### PR TITLE
fix: sample-concheck make error 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,6 @@ clean-concheck:
 	@kubectl delete job -n default --selector multi-nic-concheck
 
 sample-concheck:
-	@export SERVER_HOST_NAME ?= $(shell kubectl get nodes|tail -n 2|head -n 1|awk '{ print $1 }')
-	@export CLIENT_HOST_NAME ?= $(shell kubectl get nodes|tail -n 1|awk '{ print $1 }')
-	@echo "Test connection from ${CLIENT_HOST_NAME} to ${SERVER_HOST_NAME}"ƒ
 	@cd ./live-migration && chmod +x live_migrate.sh && ./live_migrate.sh live_iperf3 ${SERVER_HOST_NAME} ${CLIENT_HOST_NAME} 5
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/live-migration/live_migrate.sh
+++ b/live-migration/live_migrate.sh
@@ -210,11 +210,22 @@ restart_controller() {
 # iperf live
 
 # ./live_migrate.sh live_iperf3 <SERVER_HOST_NAME> <CLIENT_HOST_NAME> <LIVE_TIME>
+# or
+# ./live_migrate.sh live_iperf3 <LIVE_TIME>
 live_iperf3() {
-   SERVER_HOST_NAME=$1
-   CLIENT_HOST_NAME=$2
-   LIVE_TIME=$3
+    # use first two pods if server and client hosts are not specified.
+    if [ $# -eq 3 ]; then
+        SERVER_HOST_NAME=$1
+        CLIENT_HOST_NAME=$2
+        LIVE_TIME=$3
+    else
+        SERVER_HOST_NAME=$(kubectl get nodes|tail -n 2|head -n 1|awk '{ print $1 }')
+        CLIENT_HOST_NAME=$(kubectl get nodes|tail -n 1|awk '{ print $1 }')
+        LIVE_TIME=$1
+    fi
+
    NETWORK_NAME=$(get_netname)
+   echo "Test connection of ${NETWORK_NAME} from ${CLIENT_HOST_NAME} to ${SERVER_HOST_NAME}"
    NETWORK_REPLACEMENT=$(create_replacement .metadata.annotations.\"k8s.v1.cni.cncf.io/networks\" \"${NETWORK_NAME}\")
    SERVER_HOSTNAME_REPLACEMENT=$(create_replacement .spec.nodeName \"${SERVER_HOST_NAME}\")
    CLIENT_HOSTNAME_REPLACEMENT=$(create_replacement .spec.nodeName \"${CLIENT_HOST_NAME}\")


### PR DESCRIPTION
rebase:
- [x] https://github.com/foundation-model-stack/multi-nic-cni/pull/224

**Please do not merge until the above PR merged.**

This PR fixes the below issue when running `make sample-concheck` by moving logic to replace server-client host name to bash script.

```
/bin/sh: line 0: export: `?=': not a valid identifier
/bin/sh: line 0: export: `...`: not a valid identifier
...
```