### PR TITLE
upgrade go and CNI for daemon

### DIFF
--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.0'
+          go-version: '1.23.0'
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
       - name: Update CNI

--- a/.github/workflows/daemon_unittest.yaml
+++ b/.github/workflows/daemon_unittest.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.0'
+          go-version: '1.23.0'
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -263,8 +263,8 @@ test-daemon:
 	$(DOCKER) run -i --privileged daemon-test /bin/bash -c "cd /usr/local/build/daemon/src&&make test-verbose"
 
 build-push-kbuilder-base:
-	$(DOCKER) build -t $(IMAGE_TAG_BASE)-kbuilder -f ./daemon/dockerfiles/Dockerfile.kbuilder .
-	$(DOCKER) push $(IMAGE_TAG_BASE)-kbuilder
+	$(DOCKER) build -t $(IMAGE_TAG_BASE)-kbuilder:v$(VERSION) -f ./daemon/dockerfiles/Dockerfile.kbuilder .
+	$(DOCKER) push $(IMAGE_TAG_BASE)-kbuilder:v$(VERSION)
 
 daemon-build: test-daemon ## Build docker image with the manager.
 	$(DOCKER) tag daemon-test:latest $(IMAGE_TAG_BASE)-daemon:v$(VERSION)

--- a/cni/go.mod
+++ b/cni/go.mod
@@ -1,11 +1,11 @@
 module github.com/containernetworking/plugins
 
-go 1.17
+go 1.22
 
 require (
 	github.com/Microsoft/hcsshim v0.9.2
 	github.com/buger/jsonparser v1.1.1
-	github.com/containernetworking/cni v1.0.1
+	github.com/containernetworking/cni v1.2.3
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.16.5

--- a/cni/plugins/main/multi-nic/aws-ipvlan.go
+++ b/cni/plugins/main/multi-nic/aws-ipvlan.go
@@ -24,8 +24,11 @@ func getHostIP(devName string) net.IP {
 		return nil
 	}
 	addrs, err := netlink.AddrList(devLink, netlink.FAMILY_V4)
-	if err != nil || len(addrs) == 0 {
+	if err != nil {
 		utils.Logger.Debug(fmt.Sprintf("cannot list address on %s: %v", devName, err))
+		return nil
+	}
+	if len(addrs) == 0 {
 		return nil
 	}
 	return addrs[0].IPNet.IP.To4()

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -92,7 +92,12 @@ func (r *ConfigReconciler) getDefaultConfigSpec() multinicv1.ConfigSpec {
 		PodCNIPath:  "/opt/rt_tables",
 		HostCNIPath: "/etc/iproute2/rt_tables",
 	}
-	hostPathMounts := []multinicv1.HostPathMount{binMnt, devPluginMnt, routeMnt}
+	hwDataMnt := multinicv1.HostPathMount{
+		Name:        "hwdata",
+		PodCNIPath:  "/usr/share/hwdata",
+		HostCNIPath: "/usr/share/hwdata",
+	}
+	hostPathMounts := []multinicv1.HostPathMount{binMnt, devPluginMnt, routeMnt, hwDataMnt}
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/daemon/dockerfiles/Dockerfile
+++ b/daemon/dockerfiles/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # install go
-RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
 ENV PATH "/usr/local/go/bin:${PATH}"
 RUN mkdir -p /usr/local/app
 RUN mkdir -p /host/opt/cni/bin

--- a/daemon/dockerfiles/Dockerfile.kbuilder
+++ b/daemon/dockerfiles/Dockerfile.kbuilder
@@ -5,7 +5,7 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # install go
-RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
 
 ENV PATH "/usr/local/go/bin:${PATH}"
 
@@ -13,12 +13,9 @@ RUN mkdir -p /usr/local/build
 RUN mkdir -p /usr/local/build/cni/test-bin
 
 WORKDIR /usr/local/build
-RUN curl -sSLo kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz \
-  && tar -zxvf kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz
-RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 
 RUN cd /tmp && \ 
-   git clone -b v1.2.5 https://github.com/containernetworking/plugins.git && \
+   git clone https://github.com/containernetworking/plugins.git && \
 	 cd plugins && \
 	 ./build_linux.sh && \
 	 ls /tmp/plugins/bin && \

--- a/daemon/dockerfiles/Dockerfile.multi-nicd-test
+++ b/daemon/dockerfiles/Dockerfile.multi-nicd-test
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundation-model-stack/multi-nic-cni-kbuilder
+FROM ghcr.io/foundation-model-stack/multi-nic-cni-kbuilder:v1.2.6
 
 RUN mkdir -p /usr/local/app
 RUN mkdir -p /host/opt/cni/bin
@@ -20,6 +20,7 @@ RUN cd cni && make ginkgo-set
 COPY daemon daemon
 RUN mkdir -p /usr/local/kubebuilder
 RUN mkdir -p /usr/local/build/daemon/src/test-bin
+RUN curl -sSLo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 RUN cp setup-envtest.sh /usr/local/build/daemon/src/test-bin/setup-envtest.sh
 RUN cd daemon/src && make test-env && cp -r /usr/local/build/daemon/src/test-bin/bin /usr/local/kubebuilder/bin
 RUN mkdir -p daemon/src/test-bin

--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -2,4 +2,5 @@
 cp /usr/local/app/multi-nic /host/opt/cni/bin/multi-nic
 cp /usr/local/app/multi-nic-ipam /host/opt/cni/bin/multi-nic-ipam
 cp /usr/local/app/aws-ipvlan /host/opt/cni/bin/aws-ipvlan
+echo "Starting multi-nicd"
 ./daemon

--- a/daemon/src/Makefile
+++ b/daemon/src/Makefile
@@ -10,7 +10,6 @@ export PATH := $(PATH):$(ENVTEST_ASSETS_DIR)
 test-env: SHELL := /bin/bash
 test-env:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@test -f ${ENVTEST_ASSETS_DIR}/kubebuilder/bin/etcd || (curl -sSLo ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && tar -zxvf  ${ENVTEST_ASSETS_DIR}/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz && rm -rf ${ENVTEST_ASSETS_DIR}/kubebuilder/kubebuilder_2.0.0-alpha.1_linux_amd64 || true && mv kubebuilder_2.0.0-alpha.1_linux_amd64 ${ENVTEST_ASSETS_DIR}/kubebuilder)
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); 
 	cp -r ${ENVTEST_ASSETS_DIR}/bin /usr/local/kubebuilder/bin

--- a/daemon/src/go.mod
+++ b/daemon/src/go.mod
@@ -1,10 +1,10 @@
 module github.com/foundation-model-stack/multi-nic-cni/daemon
 
-go 1.17
+go 1.23
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/jaypipes/ghw v0.8.0
+	github.com/jaypipes/ghw v0.14.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5

--- a/daemon/src/iface/pci.go
+++ b/daemon/src/iface/pci.go
@@ -170,8 +170,9 @@ func GetTargetNetworks() []NetDeviceInfo {
 	pci, err := ghw.PCI()
 	if err != nil {
 		log.Printf("cannot get PCI info: %v", err)
+		return []NetDeviceInfo{}
 	}
-	devices := pci.ListDevices()
+	devices := pci.Devices
 	for _, device := range devices {
 		devClass, err := strconv.ParseInt(device.Class.ID, 16, 64)
 		if err != nil {

--- a/daemon/src/main.go
+++ b/daemon/src/main.go
@@ -285,7 +285,7 @@ func main() {
 	da.CleanHangingAllocation(hostName)
 	router := handleRequests()
 	daemonAddress := fmt.Sprintf("0.0.0.0:%d", DAEMON_PORT)
-	log.Printf("Listening @%s", daemonAddress)
+	log.Printf("Serving at %s", daemonAddress)
 	srv := &http.Server{
 		Addr:         daemonAddress,
 		Handler:      router,

--- a/e2e-test/cni-stub/Dockerfile
+++ b/e2e-test/cni-stub/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # install go
-RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
 ENV PATH "/usr/local/go/bin:${PATH}"
 WORKDIR /usr/local/app
 COPY . .

--- a/e2e-test/cni-stub/go.mod
+++ b/e2e-test/cni-stub/go.mod
@@ -1,3 +1,3 @@
 module github.com/foundation-model-stack/multi-nic-cni/e2e-test/cni-stub
 
-go 1.17
+go 1.23

--- a/e2e-test/daemon-stub/Dockerfile
+++ b/e2e-test/daemon-stub/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # install go
-RUN wget https://golang.org/dl/go1.17.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
 ENV PATH "/usr/local/go/bin:${PATH}"
 WORKDIR /usr/local/app
 COPY . .

--- a/e2e-test/daemon-stub/go.mod
+++ b/e2e-test/daemon-stub/go.mod
@@ -1,6 +1,6 @@
 module github.com/foundation-model-stack/multi-nic-cni/e2e-test/daemon-stub
 
-go 1.17
+go 1.23
 
 require (
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
Rebase on
- [x] https://github.com/foundation-model-stack/multi-nic-cni/pull/242

- Upgrade go to version 1.2.3 since it is required for building latest CNI plugins.
- Upgrade ghw to 0.14.0 (required addition mount to /usr/share/hwdata, otherwise will get no db error)
- Upgrade CNI to 1.2.3