### PR TITLE
upgrade version: 1.2.7

### DIFF
--- a/.github/workflows/build_push_concheck.yaml
+++ b/.github/workflows/build_push_concheck.yaml
@@ -8,7 +8,7 @@ on:
       - connection-check/**
 
 env:
-  IMAGE_VERSION: "1.2.6"
+  IMAGE_VERSION: "1.2.7"
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -16,7 +16,7 @@ on:
       - ./Makefile
 
 env:
-  VERSION: "1.2.6"
+  VERSION: "1.2.7"
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build_push_daemon.yaml
+++ b/.github/workflows/build_push_daemon.yaml
@@ -10,7 +10,7 @@ on:
       - Makefile
       
 env:
-  IMAGE_VERSION: "1.2.6"
+  IMAGE_VERSION: "1.2.7"
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/build_push_pr.yaml
+++ b/.github/workflows/build_push_pr.yaml
@@ -21,7 +21,7 @@ on:
       - cni/**
 
 env:
-  VERSION: 1.2.6-pr-${{ github.event.pull_request.number }}
+  VERSION: 1.2.7-pr-${{ github.event.pull_request.number }}
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DAEMON_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # VERSION ?= 0.0.1
-VERSION ?= 1.2.6
+VERSION ?= 1.2.7
 export CHANNELS = "alpha-1.2"
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-controller
-  newTag: v1.2.6
+  newTag: v1.2.7

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -11,7 +11,7 @@ spec:
       value: "11000"
     - name: RT_TABLE_PATH
       value: /opt/rt_tables
-    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.6
+    image: ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.7
     imagePullPolicy: Always
     mounts:
     - hostpath: /var/lib/cni/bin

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -15,4 +15,4 @@ kind: Kustomization
 images:
 - name: multi-nic-cni-daemon
   newName: ghcr.io/foundation-model-stack/multi-nic-cni-daemon
-  newTag: v1.2.6
+  newTag: v1.2.7

--- a/connection-check/concheck.yaml
+++ b/connection-check/concheck.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: multi-nic-concheck-account
       containers:
       - name: concheck
-        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.6
+        image: ghcr.io/foundation-model-stack/multi-nic-cni-concheck:v1.2.7
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/controllers/vars/vars.go
+++ b/controllers/vars/vars.go
@@ -36,7 +36,7 @@ const (
 	DefaultOperatorNamespace                  = "multi-nic-cni-operator"
 	DefaultCNIType                            = "multi-nic"
 	DefaultIPAMType                           = "multi-nic-ipam"
-	DefaultDaemonImage                        = "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.6"
+	DefaultDaemonImage                        = "ghcr.io/foundation-model-stack/multi-nic-cni-daemon:v1.2.7"
 	DefaultJoinPath                           = "/join"
 	DefaultInterfacePath                      = "/interface"
 	DefaultAddRoutePath                       = "/addl3"

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,7 +6,7 @@ export DAEMON_REGISTRY ?= ghcr.io/foundation-model-stack
 
 # DAEMON_IMG defines the image:tag used for daemon
 IMAGE_TAG_BASE = $(DAEMON_REGISTRY)/multi-nic-cni
-DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v1.2.6
+DAEMON_IMG ?= $(IMAGE_TAG_BASE)-daemon:v1.2.7
 
 
 test-verbose:

--- a/daemon/dockerfiles/Dockerfile.multi-nicd-test
+++ b/daemon/dockerfiles/Dockerfile.multi-nicd-test
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundation-model-stack/multi-nic-cni-kbuilder:v1.2.6
+FROM ghcr.io/foundation-model-stack/multi-nic-cni-kbuilder:v1.2.7
 
 RUN mkdir -p /usr/local/app
 RUN mkdir -p /host/opt/cni/bin


### PR DESCRIPTION
The version upgrade is made by 

```bash
VERSION=1.2.7 make set_version
```

Note that, there are two manually steps left as commented in https://github.com/foundation-model-stack/multi-nic-cni/issues/219#issuecomment-2743320785.