### PR TITLE
chore: upgrade ginkgo v2, add lint fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.so
 *.dylib
 bin
-testbin/*
+tools
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(ENVTEST): $(TEST_BIN_DIR)
 
 .PHONY: test
 test: $(TEST_RESULT_DIR) fmt vet ginkgo manifests generate envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(TEST_BIN_DIR)/ginkgo run --cover --coverprofile=cover.out --json-report unittest-report.json   ./controllers/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(TEST_BIN_DIR)/ginkgo run --cover --coverprofile=cover.out --json-report unittest-report.json   ./controllers/...  ./internal/...
 	@./hack/json-report-to-markdown.sh unittest-report "Unit Test"
 	@rm unittest-report.json
 

--- a/controllers/config_test.go
+++ b/controllers/config_test.go
@@ -5,7 +5,7 @@ import (
 
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
 	"github.com/foundation-model-stack/multi-nic-cni/internal/vars"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 	//+kubebuilder:scaffold:imports

--- a/controllers/daemon_test.go
+++ b/controllers/daemon_test.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/hostinterface_test.go
+++ b/controllers/hostinterface_test.go
@@ -8,7 +8,7 @@ package controllers_test
 import (
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
 	"github.com/foundation-model-stack/multi-nic-cni/controllers"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/controllers/ippool_test.go
+++ b/controllers/ippool_test.go
@@ -90,13 +90,9 @@ func checkSyncAllocation(allocationMap map[string]map[string]multinicv1.Allocati
 }
 
 func checkSyncAllocationWithMap(allocationMap, crAllocationMap map[string]map[string]multinicv1.Allocation, ippools []multinicv1.IPPoolSpec, expectedChanged map[int]bool) {
-	fmt.Printf("crAllocationMap: %v\n", crAllocationMap)
 	for interfaceIndex := range interfaceNames {
 		ippool := ippools[interfaceIndex]
-		fmt.Printf("befor %v \n", allocationMap)
 		changed, newAllocations := MultiNicnetworkReconcilerInstance.CIDRHandler.GetSyncAllocations(ippool, allocationMap, crAllocationMap)
-		fmt.Printf("after %v - %d\n", allocationMap, len(interfaceNames)-interfaceIndex-1)
-		fmt.Printf("allocations %v\n", newAllocations)
 		// must be updated (deleted)
 		Expect(len(allocationMap[defName])).To(Equal(len(interfaceNames) - interfaceIndex - 1))
 		// must be changed
@@ -187,10 +183,7 @@ var _ = Describe("Unsync IPPool Test", func() {
 		}
 		for interfaceIndex := range interfaceNames {
 			ippool := ippools[interfaceIndex]
-			fmt.Printf("befor %v \n", allocationMap)
 			changed, newAllocations := MultiNicnetworkReconcilerInstance.CIDRHandler.GetSyncAllocations(ippool, allocationMap, crAllocationMap)
-			fmt.Printf("after %v - %d\n", allocationMap, len(interfaceNames)-interfaceIndex-1)
-			fmt.Printf("allocations %v\n", newAllocations)
 			// must be changed
 			Expect(changed).To(Equal(true))
 			Expect(len(newAllocations)).To(Equal(0))

--- a/controllers/ippool_test.go
+++ b/controllers/ippool_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -10,7 +10,7 @@ import (
 
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
 	"github.com/foundation-model-stack/multi-nic-cni/internal/compute"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/multinicipam_test.go
+++ b/controllers/multinicipam_test.go
@@ -19,7 +19,6 @@ func updateCIDR(multinicnetwork *multinicv1.MultiNicNetwork, cidr multinicv1.CID
 	def := cidr.Config
 	excludes := compute.SortAddress(def.ExcludeCIDRs)
 	entriesMap, changed := MultiNicnetworkReconcilerInstance.CIDRHandler.UpdateEntries(cidr, excludes, new)
-	fmt.Printf("EntryMap: %v\n", entriesMap)
 	Expect(changed).To(Equal(expectChange))
 
 	expectedPodCIDR := 0
@@ -40,9 +39,7 @@ func updateCIDR(multinicnetwork *multinicv1.MultiNicNetwork, cidr multinicv1.CID
 		totalPodCIDR := 0
 		for _, entry := range entriesMap {
 			totalPodCIDR += len(entry.Hosts)
-			fmt.Printf("hosts: %v\n", entry.Hosts)
 		}
-		fmt.Printf("cidr total pod: %d\n", totalPodCIDR)
 		Expect(totalPodCIDR).To(Equal(expectedPodCIDR))
 	}
 	reservedInterfaceIndex := make(map[int]bool)
@@ -77,35 +74,35 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		cidr = updateCIDR(multinicnetwork, cidr, true, true)
 		cidr = updateCIDR(multinicnetwork, cidr, false, false)
 		// Add Host
-		fmt.Println("Add Host")
+		By("Add Host")
 		newHostName := "newHost"
 		newHostIndex := MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SafeCache.GetSize()
 		newHif := generateNewHostInterface(newHostName, interfaceNames, networkPrefixes, newHostIndex)
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Interface
-		fmt.Println("Add Interface")
+		By("Add Interface")
 		newInterfaceName := "eth99"
 		newNetworkPrefix := "0.0.0.0"
 		newHif = generateNewHostInterface(newHostName, append(interfaceNames, newInterfaceName), append(networkPrefixes, newNetworkPrefix), newHostIndex)
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Remove Interface
-		fmt.Println("Remove Interface")
+		By("Remove Interface")
 		newHif = generateNewHostInterface(newHostName, interfaceNames, networkPrefixes, newHostIndex)
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Interface back
-		fmt.Println("Add Interface Back")
+		By("Add Interface Back")
 		newHif = generateNewHostInterface(newHostName, append(interfaceNames, newInterfaceName), append(networkPrefixes, newNetworkPrefix), newHostIndex)
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Remove Host
-		fmt.Println("Remove Host")
+		By("Remove Host")
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SafeCache.UnsetCache(newHostName)
 		cidr = updateCIDR(multinicnetwork, cidr, false, true)
 		// Add Host back
-		fmt.Println("Add Host Back")
+		By("Add Host Back")
 		MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.SetCache(newHostName, newHif)
 		updateCIDR(multinicnetwork, cidr, false, true)
 		// Clean up
@@ -147,7 +144,6 @@ var _ = Describe("Test Multi-NIC IPAM", func() {
 		cidrSpec, err := MultiNicnetworkReconcilerInstance.CIDRHandler.GenerateCIDRFromHostSubnet(*ipamConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(cidrSpec.CIDRs)).To(Equal(len(interfaceNames)))
-		fmt.Println(cidrSpec)
 		hostIPs := MultiNicnetworkReconcilerInstance.CIDRHandler.GetHostAddressesToExclude()
 		Expect(len(hostIPs)).To(BeEquivalentTo(len(interfaceNames) * MultiNicnetworkReconcilerInstance.CIDRHandler.HostInterfaceHandler.GetSize()))
 	})

--- a/controllers/multinicnetwork_test.go
+++ b/controllers/multinicnetwork_test.go
@@ -12,7 +12,7 @@ import (
 	multinicv1 "github.com/foundation-model-stack/multi-nic-cni/api/v1"
 	. "github.com/foundation-model-stack/multi-nic-cni/controllers"
 	"github.com/foundation-model-stack/multi-nic-cni/internal/plugin"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/plugin_test.go
+++ b/controllers/plugin_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	. "github.com/foundation-model-stack/multi-nic-cni/controllers"
 	"github.com/foundation-model-stack/multi-nic-cni/internal/plugin"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -14,8 +14,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -309,12 +310,14 @@ var _ = BeforeSuite(func() {
 	}
 	createdNicClusterPolicy := &plugin.NicClusterPolicy{}
 	Expect(mellanoxPlugin.MellanoxNicClusterPolicyHandler.Create(metav1.NamespaceAll, nicClusterPolicy, createdNicClusterPolicy)).Should(Succeed())
-}, 60)
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func(g Gomega) {
+		err := testEnv.Stop()
+		g.Expect(err).NotTo(HaveOccurred())
+	}).WithTimeout(60 * time.Second).WithPolling(1000 * time.Millisecond).Should(Succeed())
 })
 
 func generateNodes() []corev1.Node {

--- a/document/docs/contributing/local_build_push.md
+++ b/document/docs/contributing/local_build_push.md
@@ -80,11 +80,11 @@
 
 ## Test
 ```bash
-# test golang linter (available after v1.0.4)
-make golint
+# test golang linter
+make lint
 # test controller 
 make test
-# test daemon (available after v1.0.3)
+# test daemon
 make test-daemon
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/containernetworking/cni v1.0.1
 	github.com/go-logr/logr v1.4.2
-	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.33.1
+	github.com/onsi/ginkgo/v2 v2.20.1
+	github.com/onsi/gomega v1.36.1
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.26.0
@@ -15,6 +15,95 @@ require (
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
 	sigs.k8s.io/controller-runtime v0.19.1
+)
+
+require (
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.6 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/cel-go v0.20.1 // indirect
+	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240827171923-fa2c70bbbfe5 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/prometheus/client_golang v1.19.1 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/common v0.55.0 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
+	go.opentelemetry.io/otel v1.28.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
+	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
+	go.opentelemetry.io/otel/trace v1.28.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/crypto v0.30.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
+	golang.org/x/net v0.32.0 // indirect
+	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/term v0.27.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.28.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
+	google.golang.org/grpc v1.65.0 // indirect
+	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.31.0 // indirect
+	k8s.io/apiserver v0.31.0 // indirect
+	k8s.io/component-base v0.31.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20220211145901-aa98df527546

--- a/hack/json-report-to-markdown.sh
+++ b/hack/json-report-to-markdown.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# 
+FILENAME=$1
+TITLE=$2
+OUTPUT=./testing/${FILENAME}.md
+
+# write header
+echo "# ${TITLE}" > ${OUTPUT}
+echo "" >> ${OUTPUT}
+echo "Test | Description | File " >> ${OUTPUT}
+echo "---|---|---" >> ${OUTPUT}
+
+# extract
+CSV=$(mktemp)
+jq -r '.[]|select(.SpecReports!=null)|.SpecReports[]|select(.ContainerHierarchyTexts!=null) | [(.ContainerHierarchyTexts | join("/")), .LeafNodeText, .LeafNodeLocation.FileName] | @tsv ' \
+ < ${FILENAME}.json | sort | awk -F'\t' '{ printf "| %s | %s | %s |\n", $1, $2, $3 }'  >> ${OUTPUT}
+
+echo "Report saved in ${OUTPUT}"

--- a/internal/compute/compute.go
+++ b/internal/compute/compute.go
@@ -38,6 +38,8 @@ func (c CIDRCompute) appendMask(baseMask []byte, block int) [4]byte {
 	return output
 }
 
+// addAddress adds the addValue to the baseAddress with the mask.
+// It returns the new IP address and an error if the addValue is invalid.
 func (c CIDRCompute) addAddress(baseAddress []byte, mask []byte, block int, addValue int) ([4]byte, error) {
 	// check if valid sum value
 	maxValue := math.Pow(2, float64(block)) - 1
@@ -92,6 +94,7 @@ func (c CIDRCompute) addAddress(baseAddress []byte, mask []byte, block int, addV
 	return output, nil
 }
 
+// CheckIfTabuIndex checks if the given index is tabu in the context of the base CIDR and excludes.
 func (c CIDRCompute) CheckIfTabuIndex(baseCIDR string, index int, blocksize int, excludes []string) bool {
 	baseBlock, _ := strconv.ParseInt(strings.Split(baseCIDR, "/")[1], 10, 64)
 	for _, exclude := range excludes {
@@ -111,6 +114,7 @@ func (c CIDRCompute) CheckIfTabuIndex(baseCIDR string, index int, blocksize int,
 	return false
 }
 
+// FindAvailableIndex returns the first reusable index in the given range of indexes.
 func (c CIDRCompute) FindAvailableIndex(indexes []int, leftIndex int, startIndex int) int {
 	if len(indexes) == 0 {
 		return -1
@@ -135,6 +139,9 @@ func (c CIDRCompute) FindAvailableIndex(indexes []int, leftIndex int, startIndex
 	}
 }
 
+// ComputeNet computes the network address for a given CIDR and index.
+// It takes the base CIDR, index, and blocksize as input parameters.
+// It returns the network address as a [4]byte array and an error if any.
 func (c CIDRCompute) ComputeNet(baseCIDR string, index int, blocksize int) ([4]byte, error) {
 	startIPStr := strings.Split(baseCIDR, "/")[0]
 	startIP := net.ParseIP(startIPStr)
@@ -154,30 +161,15 @@ func (c CIDRCompute) ComputeNet(baseCIDR string, index int, blocksize int) ([4]b
 	return cidrInByte, nil
 }
 
-func (c CIDRCompute) GetIPVLANSubnet(interfaceNodeCIDR [4]byte, subnet string, interfaceBlock int) string {
-	baseBlock, _ := strconv.ParseInt(strings.Split(subnet, "/")[1], 10, 64)
-	_, subnetNet, _ := net.ParseCIDR(subnet)
-	mask := subnetNet.Mask
-	interfaceMask := c.appendMask(mask, interfaceBlock)
-	interfaceIPMask := net.IPv4Mask(interfaceMask[0], interfaceMask[1], interfaceMask[2], interfaceMask[3])
-	intefaceNodeIP := net.IPv4(interfaceNodeCIDR[0], interfaceNodeCIDR[1], interfaceNodeCIDR[2], interfaceNodeCIDR[3])
-	maskedInterfaceNodeIP := intefaceNodeIP.Mask(interfaceIPMask).To4()
-
-	return fmt.Sprintf("%s/%d", maskedInterfaceNodeIP, int(baseBlock)+interfaceBlock)
-}
-
-func (c CIDRCompute) GetPodSubnet(interfaceNodeCIDR [4]byte, subnet string, interfaceBlock int, nodeBlock int) string {
-	baseBlock, _ := strconv.ParseInt(strings.Split(subnet, "/")[1], 10, 64)
-	blockSize := int(baseBlock) + interfaceBlock + nodeBlock
-	return fmt.Sprintf("%s/%d", bytesToStr(interfaceNodeCIDR), blockSize)
-}
-
+// GetCIDRFromByte returns a CIDR string from a byte array, subnet, and block size.
 func (c CIDRCompute) GetCIDRFromByte(cidrInByte [4]byte, subnet string, blocksize int) string {
 	baseBlock, _ := strconv.ParseInt(strings.Split(subnet, "/")[1], 10, 64)
 	blockSize := int(baseBlock) + blocksize
 	return fmt.Sprintf("%s/%d", bytesToStr(cidrInByte), blockSize)
 }
 
+// GetIndexInRange returns a boolean indicating if the pod IP address is within the pod CIDR range,
+// and the index of the pod IP address within the range.
 func (c CIDRCompute) GetIndexInRange(podCIDR string, podIPAddress string) (bool, int) {
 	startPodIP, podNet, _ := net.ParseCIDR(podCIDR)
 	netIP, _, _ := net.ParseCIDR(podIPAddress + "/32")

--- a/internal/compute/compute_test.go
+++ b/internal/compute/compute_test.go
@@ -1,0 +1,58 @@
+package compute_test
+
+import (
+	. "github.com/foundation-model-stack/multi-nic-cni/internal/compute"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test CIDRCompute", func() {
+	compute := CIDRCompute{}
+
+	DescribeTable("ComputeNet", func(baseCIDR string, index int, blocksize int, expectedOutput string, expectedError bool) {
+		vlanInByte, err := compute.ComputeNet(baseCIDR, index, blocksize)
+		Expect(err == nil).To(BeEquivalentTo(!expectedError))
+		if !expectedError {
+			vlanCIDR := compute.GetCIDRFromByte(vlanInByte, baseCIDR, blocksize)
+			Expect(vlanCIDR).To(BeEquivalentTo(expectedOutput))
+		}
+	},
+		Entry("simple", "192.168.0.0/16", 0, 2, "192.168.0.0/18", false),
+		Entry("invalid CIDR", "192.168.0.0", 0, 2, "", true),
+		Entry("invalid Index", "192.168.0.0/16", 4, 2, "", true),
+	)
+
+	DescribeTable("CheckIfTabuIndex", func(baseCIDR string, index int, blocksize int, excludes []string, expected bool) {
+		output := compute.CheckIfTabuIndex(baseCIDR, index, blocksize, excludes)
+		Expect(output).To(BeEquivalentTo(expected))
+	},
+		Entry("no excludes", "192.168.0.0/16", 0, 8, []string{}, false),
+		Entry("tabu index", "192.168.0.0/16", 0, 8, []string{"192.168.0.0/24"}, true),
+		Entry("cover tabu index", "192.168.0.0/16", 0, 8, []string{"192.168.0.0/8"}, true),
+		Entry("not tabu index", "192.168.0.0/16", 0, 8, []string{"192.168.1.0/24"}, false),
+	)
+
+	DescribeTable("FindAvailableIndex", func(indexes []int, leftIndex, startIndex, expected int) {
+		output := compute.FindAvailableIndex(indexes, leftIndex, startIndex)
+		Expect(output).To(BeEquivalentTo(expected))
+	},
+		Entry("empty indexes", []int{}, 0, 0, -1),
+		Entry("single index assigned", []int{0}, 0, 0, -1),
+		Entry("single index available", []int{1}, 0, 0, 0),
+		Entry("multiple index assigned", []int{0, 1, 2}, 0, 0, -1),
+		Entry("available index in left part", []int{0, 2, 3}, 0, 0, 1),
+		Entry("available index in right part", []int{0, 1, 3}, 0, 0, 2),
+		Entry("available index in middle", []int{0, 1, 3, 4}, 0, 0, 2),
+	)
+
+	DescribeTable("GetIndexInRange", func(podCIDR string, podIPAddress string, expectedContains bool, expectedPodIndex int) {
+		contains, podIndex := compute.GetIndexInRange(podCIDR, podIPAddress)
+		Expect(contains).To(BeEquivalentTo(expectedContains))
+		Expect(podIndex).To(BeEquivalentTo(expectedPodIndex))
+	},
+		Entry("valid CIDR and IP", "192.168.1.0/24", "192.168.1.100", true, 100),
+		Entry("invalid CIDR and IP", "192.168.1.0/24", "192.168.2.100", false, -1),
+		Entry("same CIDR and IP", "192.168.1.0/24", "192.168.1.0", true, 0),
+		Entry("different CIDR and IP", "10.0.0.0/8", "192.168.1.100", false, -1),
+	)
+})

--- a/internal/compute/suite_test.go
+++ b/internal/compute/suite_test.go
@@ -1,0 +1,13 @@
+package compute
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCompute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Compute Suite")
+}

--- a/internal/plugin/macvlan.go
+++ b/internal/plugin/macvlan.go
@@ -23,8 +23,8 @@ type MACVLANPlugin struct {
 type MACVLANTypeNetConf struct {
 	types.NetConf
 	Master string `json:"master"` // Name of the master interfce (e.g., eth0)
-	Mode string `json:"mode"`  // Mod of the macvlan interface (e.g., bridge, private)
-	MTU  int    `json:"mtu"`
+	Mode   string `json:"mode"`   // Mod of the macvlan interface (e.g., bridge, private)
+	MTU    int    `json:"mtu"`
 }
 
 func (p *MACVLANPlugin) Init(config *rest.Config) error {
@@ -37,7 +37,7 @@ func (p *MACVLANPlugin) GetConfig(net multinicv1.MultiNicNetwork, hifList map[st
 	conf := &MACVLANTypeNetConf{}
 	conf.CNIVersion = net.Spec.MainPlugin.CNIVersion
 	conf.Type = MACVLAN_TYPE
-	conf.Master = args["master"]  //Populate the master field
+	conf.Master = args["master"] // Populate the master field
 	conf.Mode = args["mode"]
 	val, err := getInt(args, "mtu")
 	if err == nil {

--- a/testing/unittest-report.md
+++ b/testing/unittest-report.md
@@ -14,6 +14,24 @@ Test | Description | File
 | Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
 | Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one when some is missing | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
 | Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one when some is missing and some with new info | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Test CIDRCompute/CheckIfTabuIndex | cover tabu index | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/CheckIfTabuIndex | no excludes | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/CheckIfTabuIndex | not tabu index | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/CheckIfTabuIndex | tabu index | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/ComputeNet | invalid CIDR | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/ComputeNet | invalid Index | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/ComputeNet | simple | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | available index in left part | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | available index in middle | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | available index in right part | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | empty indexes | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | multiple index assigned | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | single index assigned | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/FindAvailableIndex | single index available | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/GetIndexInRange | different CIDR and IP | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/GetIndexInRange | invalid CIDR and IP | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/GetIndexInRange | same CIDR and IP | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
+| Test CIDRCompute/GetIndexInRange | valid CIDR and IP | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/internal/compute/compute_test.go |
 | Test GetConfig of main plugins | ipvlan main plugin | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
 | Test GetConfig of main plugins | macvlan main plugin | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
 | Test GetConfig of main plugins | mellanox main plugin - GetSrIoVResource | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |

--- a/testing/unittest-report.md
+++ b/testing/unittest-report.md
@@ -1,0 +1,40 @@
+# Unit Test
+
+Test | Description | File 
+---|---|---
+| Config Test | Check update from ConfigSpec | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/config_test.go |
+| Daemon Test | Test TryGetDaemonPod for tainted daemon | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/daemon_test.go |
+| Daemon Test | Test TryGetDaemonPod for valid daemon | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/daemon_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with a single device | can add new while leave old one | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with a single device | can check no change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with a single device | can detect change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with a single device | can leave old one | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with more than one devices | can check no change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with more than one devices | can check no change in swop order | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one when some is missing | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Host Interface Test/UpdateNewInterfaces - original with more than one devices | can leave old one when some is missing and some with new info | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/hostinterface_test.go |
+| Test GetConfig of main plugins | ipvlan main plugin | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
+| Test GetConfig of main plugins | macvlan main plugin | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
+| Test GetConfig of main plugins | mellanox main plugin - GetSrIoVResource | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
+| Test GetConfig of main plugins | sriov main plugin with resource name | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
+| Test GetConfig of main plugins | sriov main plugin without resource name | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/plugin_test.go |
+| Test Multi-NIC IPAM | Dynamically compute CIDR | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicipam_test.go |
+| Test Multi-NIC IPAM | Empty subnet | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicipam_test.go |
+| Test Multi-NIC IPAM | Sync CIDR/IPPool | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicipam_test.go |
+| Test definition changes check | detect annotation change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test definition changes check | detect config change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test definition changes check | detect no change | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test deploying MultiNicNetwork | successfully create/delete network attachment definition | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test deploying MultiNicNetwork | successfully create/delete network attachment definition on new namespace | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test multinicnetwork status change check | detect change from no status | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test multinicnetwork status change check | detect change on compute results | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Test multinicnetwork status change check | detect change on simple status | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/multinicnetwork_test.go |
+| Unsync IPPool Test | All new | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Already synced | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Assignment on one interface is missing | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Deleted pods pending | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Deleted pods pending and new pod assigned the same index | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Duplicated allocation | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Same pod different IP | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |
+| Unsync IPPool Test | Should all clean | /Users/aa404681/Documents/internal_ws/cni/multi-nic-cni-operator/controllers/ippool_test.go |


### PR DESCRIPTION
Relevant issues:
- https://github.com/foundation-model-stack/multi-nic-cni/issues/214

Rebase on 
- [x] https://github.com/foundation-model-stack/multi-nic-cni/pull/261 (please merge the base PR first)

This PR 
- upgrade ginkgo to v2 and use ginkgo instead of go test
- rearrange Makefile and bin folder 
   - bin/manager
   - tools/devbin (dev-related binary e.g., kustomize, controller-gen, golangci-lint)
   - tools/testbin (test-related binary and script e.g., ginkgo, setenv)
- produce [unittest-report.md](https://github.com/foundation-model-stack/multi-nic-cni/blob/9c5df065ca9cf8b1d762e9337986ab202867a70f/testing/unittest-report.md) in `testing` folder
- replace `golint` with `lint` and add `fix` target for lint run and fix respectively