### PR TITLE
Add default channel into bundle annotations.

### DIFF
--- a/.github/workflows/build_push_controller.yaml
+++ b/.github/workflows/build_push_controller.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
             echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
             echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
-            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.37.0" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2" >> $GITHUB_ENV
       - name: download operator-sdk
         run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
       - name: move operator-sdk to binary path

--- a/.github/workflows/build_push_pr.yaml
+++ b/.github/workflows/build_push_pr.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
             echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
             echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
-            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.37.0" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2" >> $GITHUB_ENV
       - name: download operator-sdk
         run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
       - name: move operator-sdk to binary path

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
             echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >> $GITHUB_ENV
             echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
-            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.37.0" >> $GITHUB_ENV
+            echo "OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2" >> $GITHUB_ENV
       - name: download operator-sdk
         run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/operator-sdk_${{ env.OS }}_${{ env.ARCH }}
       - name: move operator-sdk to binary path

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ export IMAGE_REGISTRY ?= ghcr.io/foundation-model-stack
 # VERSION ?= 0.0.1
 VERSION ?= 1.2.7
 export CHANNELS = "alpha-1.2"
+export DEFAULT_CHANNEL = "alpha-1.2"
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,8 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multi-nic-cni-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha-1.2
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha-1.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 


### PR DESCRIPTION
This PR is to cope with the proposed fix of community-operators issue with missing default channel in the bundle: https://github.com/k8s-operatorhub/community-operators/pull/5978