### PR TITLE
chore: sync doc to add release 1.2.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,6 +13,7 @@ assignees: ''
 - [ ] Make sure that doc branch is synced to main branch by pushing PR from doc to main.
 - [ ] Make sure that all workflows on the main branch are completed successfully.
 - [ ] Create a release on GitHub repository: https://github.com/foundation-model-stack/multi-nic-cni/releases
+- [ ] Prepare kbuilder image for new version. Dispatch the [workflow](https://github.com/foundation-model-stack/multi-nic-cni/actions/workflows/build_push_kbuilder.yaml) with image version X.Y.Z.
 - [ ] Set new version with the following command and push a PR upgrade version: X.Y.Z to the main branch.
 - [ ] Update catalog template file and push PR to community operator hub - [OpenShift](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
 - [ ] Update catalog template file and push PR to community operator hub - [OperatorHub.io](https://github.com/k8s-operatorhub/community-operators)

--- a/document/docs/contributing/maintainer.md
+++ b/document/docs/contributing/maintainer.md
@@ -10,12 +10,14 @@
     * Create a new tag with format `release-vX.Y.Z` from the main branch. 
     * Add [auto-generate release note](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
     * Insert summarized updates from [milestone](https://github.com/foundation-model-stack/multi-nic-cni/milestones).
-4. Set new version with the following command and push a PR `upgrade version: X.Y.Z` to the main branch.
+
+4. Prepare kbuilder image for new version. Dispatch the [workflow](https://github.com/foundation-model-stack/multi-nic-cni/actions/workflows/build_push_kbuilder.yaml) with image version `X.Y.Z`.
+5. Set new version with the following command and push a PR `upgrade version: X.Y.Z` to the main branch.
     
         make set_version X.Y.Z
 
-5. Update catalog template file and push PR to community operator hub:
+6. Update catalog template file and push PR to community operator hub:
     * https://github.com/redhat-openshift-ecosystem/community-operators-prod
     * https://github.com/k8s-operatorhub/community-operators
 
-6. Once the above PR merged, update release page in documentation. Check [documentation update guide](../contributing/local_build_push.md#documentation-update).
+7. Once the above PR merged, update release page in documentation. Check [documentation update guide](../contributing/local_build_push.md#documentation-update).

--- a/document/docs/release/alpha-1.2.md
+++ b/document/docs/release/alpha-1.2.md
@@ -1,5 +1,16 @@
 # Alpha 1.2 Channel
 
+## v1.2.7
+- support macvlan plugin
+- code enhancements:
+    * refactor code structure (add internal packages)
+    * upgrade test to ginkgo V2
+    * generate measurable test coverage results
+    * improve test coverage to 60%
+- fixes:
+    * correct sample multinicnetwork for macvlan+whereabouts IPAM
+    * handle error from ghw.PCI call
+
 ## v1.2.6
 
 - upgrade go version
@@ -10,8 +21,8 @@
 - update concept image, user and contributing guide
 - rewrite the highlighted features and add demo and references
 - fix bugs: 
-  * [sample-concheck make error](https://github.com/foundation-model-stack/multi-nic-cni/pull/235)
-  * [failed to load netconf: post fail: Post "http://localhost:11000/select": EOF](https://github.com/foundation-model-stack/multi-nic-cni/issues/240)
+    * [sample-concheck make error](https://github.com/foundation-model-stack/multi-nic-cni/pull/235)
+    * [failed to load netconf: post fail: Post "http://localhost:11000/select": EOF](https://github.com/foundation-model-stack/multi-nic-cni/issues/240)
 
 ## v1.2.5
 

--- a/document/docs/release/index.md
+++ b/document/docs/release/index.md
@@ -6,4 +6,4 @@ Channel|Version|IPVLAN L2/L3|AWS IPVLAN|Mellanox Host Device|IP-less (zero host 
 [stable-1.2](./stable-1.2.md)|v1.2.4|&check;|&check;|&check;|X|X
 [beta](./beta.md)|v1.2.3|&check;|&check;|&check;|X|X
 [alpha](./alpha.md)|v1.3.0|&check;|&check;|&check;|&check;|&check;
-[alpha-1.2](./alpha-1.2.md)|v1.2.6|&check;|&check;|&check;|X|X
+[alpha-1.2](./alpha-1.2.md)|v1.2.7|&check;|&check;|&check;|X|X


### PR DESCRIPTION
Address last step in
- https://github.com/foundation-model-stack/multi-nic-cni/issues/271

Requires operator hub uploading first