### PR TITLE
ci: add kbuilder dispatch workflow

### DIFF
--- a/.github/workflows/build_push_kbuilder.yaml
+++ b/.github/workflows/build_push_kbuilder.yaml
@@ -1,0 +1,37 @@
+name: Build and push daemon kbuilder image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'kbuilder image version'
+        required: true
+
+env:
+  IMAGE_VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/multi-nic-cni-kbuilder
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.23.0'
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:v${{ env.IMAGE_VERSION }}
+          file: ./daemon/dockerfiles/Dockerfile.kbuilder


### PR DESCRIPTION
Add workflow to build and push kbuilder base image for daemon container. 
This is supposed to be run on demand to reduce build time.