### PR TITLE
fix: correct interface name on host-device ADD and prevent tabu prefix

### DIFF
--- a/daemon/src/iface/iface.go
+++ b/daemon/src/iface/iface.go
@@ -24,6 +24,10 @@ type InterfaceInfoType struct {
 	PciAddress    string `json:"pciAddress"`
 }
 
+const (
+	zombiePrefix = "net1"
+)
+
 var interfaceInfoCache = InitSafeCache()
 
 func GetInterfaceInfoCache() map[string]InterfaceInfoType {
@@ -121,9 +125,12 @@ func GetInterfaces() []InterfaceInfoType {
 	if err != nil {
 		log.Printf("cannot get default subnet: %v", err)
 	}
-
 	for _, netDevice := range netDevices {
 		devName := netDevice.Name
+		if strings.HasPrefix(devName, zombiePrefix) {
+			log.Printf("found zombie interface name %s, skip", devName)
+			continue
+		}
 		devLink, err := netlink.LinkByName(devName)
 		if err != nil {
 			log.Printf("cannot find link %s: %v", devName, err)


### PR DESCRIPTION
address 
- https://github.com/foundation-model-stack/multi-nic-cni/issues/278

Follow reproduce steps to confirm the fix.

When redeploying the job after host interface becomes wrongly, the CNI should be able to rename the interface back and show the below log:

```
{"level":"debug","ts":"2025-05-26T12:21:48.824Z","caller":"multi-nic/utils.go:136","msg":"successfully rename host device net1-0 to enpxxx"}
...
```

And the pod should be able to run.
