### PR TITLE
feat: add multi-config and handle static ips

### DIFF
--- a/cni/plugins/main/multi-nic/utils.go
+++ b/cni/plugins/main/multi-nic/utils.go
@@ -20,6 +20,27 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	MultiConfigIPAMType = "multi-config"
+	WhereaboutsIPAMType = "whereabouts"
+)
+
+type IPAMExtract struct {
+	IPAM map[string]interface{} `json:"ipam"`
+}
+
+type MultiIPAMConfig struct {
+	Name     string
+	Type     string                            `json:"type"`
+	IpamType string                            `json:"ipam_type"`
+	Args     map[string]map[string]interface{} `json:"args"`
+	Routes   []*types.Route                    `json:"routes"`
+}
+
+type MultiIPAMExtract struct {
+	IPAM MultiIPAMConfig `json:"ipam"`
+}
+
 // getPodInfo extracts pod Name and Namespace from cniArgs
 func getPodInfo(cniArgs string) (string, string) {
 	splits := strings.Split(cniArgs, ";")
@@ -35,6 +56,57 @@ func getPodInfo(cniArgs string) (string, string) {
 	return podName, podNamespace
 }
 
+// getStaticIPs extracts static ip from cniArgs
+// reference: https://github.com/k8snetworkplumbingwg/multus-cni/blob/e2e8cfb677e8cf5352f737b5004effed7518d71a/pkg/multus/multus.go#L324
+func getStaticIPs(cniArgs string) ([]string, string) {
+	splits := strings.Split(cniArgs, ";")
+	for index, split := range splits {
+		if strings.HasPrefix(split, "IP=") {
+			ipsStr := strings.TrimPrefix(split, "IP=")
+			newItems := splits[0:index]
+			if index < len(split)-1 {
+				newItems = append(newItems, splits[index+1:len(splits)]...)
+			}
+			newCniArgs := strings.Join(newItems, ";")
+			return strings.Split(ipsStr, ","), newCniArgs
+		}
+	}
+	return []string{}, cniArgs
+}
+
+func getMultiIPAMConfig(multiNicConfBytes []byte) (*MultiIPAMExtract, error) {
+	ipamObject := &MultiIPAMExtract{}
+	err := json.Unmarshal(multiNicConfBytes, ipamObject)
+	return ipamObject, err
+
+}
+
+func getMultiIPAMConfigBytes(multiNicConfBytes []byte) (map[string][]byte, error) {
+	multiIPAMConfigBytes := make(map[string][]byte)
+	ipamObject, err := getMultiIPAMConfig(multiNicConfBytes)
+	if err == nil && ipamObject.IPAM.Args != nil {
+		for masterName, singleIPAMObject := range ipamObject.IPAM.Args {
+			singleIPAMConfBytes := make(map[string]interface{})
+			if singleIPAMObject == nil {
+				utils.Logger.Debug(fmt.Sprintf("ipamObject.IPAM.Args not defined on %s", masterName))
+				continue
+			}
+			// set type
+			singleIPAMConfBytes["type"] = ipamObject.IPAM.IpamType
+			if ipamObject.IPAM.IpamType == WhereaboutsIPAMType {
+				singleIPAMConfBytes["network_name"] = masterName
+			}
+			// set args
+			for k, v := range singleIPAMObject {
+				singleIPAMConfBytes[k] = v
+			}
+			ipamBytes, _ := json.Marshal(singleIPAMConfBytes)
+			multiIPAMConfigBytes[masterName] = ipamBytes
+		}
+	}
+	return multiIPAMConfigBytes, err
+}
+
 // injectIPAM injects ipam bytes to config
 func injectMultiNicIPAM(singleNicConfBytes, multiNicConfBytes []byte, ipConfigs []*current.IPConfig, ipIndex int) ([]byte, map[string][]*netlink.NexthopInfo) {
 	var ipConfig *current.IPConfig
@@ -48,11 +120,17 @@ func injectSingleNicIPAM(singleNicConfBytes []byte, multiNicConfBytes []byte) ([
 	return replaceSingleNicIPAM(singleNicConfBytes, multiNicConfBytes)
 }
 
-type IPAMExtract struct {
-	IPAM map[string]interface{} `json:"ipam"`
+func replaceSingleNicIPAM(singleNicConfBytes, multiNicConfBytes []byte) ([]byte, map[string][]*netlink.NexthopInfo) {
+	ipamObject := &IPAMExtract{}
+	err := json.Unmarshal(multiNicConfBytes, ipamObject)
+	if err == nil {
+		ipamBytes, _ := json.Marshal(ipamObject.IPAM)
+		return replaceSingleNicIPAMWithMultiConfig(singleNicConfBytes, multiNicConfBytes, ipamBytes)
+	}
+	return singleNicConfBytes, nil
 }
 
-func replaceSingleNicIPAM(singleNicConfBytes, multiNicConfBytes []byte) ([]byte, map[string][]*netlink.NexthopInfo) {
+func replaceSingleNicIPAMWithMultiConfig(singleNicConfBytes, multiNicConfBytes, ipamBytes []byte) ([]byte, map[string][]*netlink.NexthopInfo) {
 	confStr := string(singleNicConfBytes)
 	ipamObject := &IPAMExtract{}
 	err := json.Unmarshal(multiNicConfBytes, ipamObject)
@@ -62,7 +140,6 @@ func replaceSingleNicIPAM(singleNicConfBytes, multiNicConfBytes []byte) ([]byte,
 			ipamObject.IPAM["routes"] = nonMultiPathRoutes
 		}
 
-		ipamBytes, _ := json.Marshal(ipamObject.IPAM)
 		singleIPAM := fmt.Sprintf("\"ipam\":%s", string(ipamBytes))
 		injectedStr := strings.ReplaceAll(confStr, "\"ipam\":{}", singleIPAM)
 		return []byte(injectedStr), multiPathRoutes

--- a/config/samples/multinicnetwork/ipvlanl2_multiconfig.yaml
+++ b/config/samples/multinicnetwork/ipvlanl2_multiconfig.yaml
@@ -1,0 +1,25 @@
+apiVersion: multinic.fms.io/v1
+kind: MultiNicNetwork
+metadata:
+  name: multinic-multiconfig
+spec:
+  subnet: ""
+  ipam: |
+    {
+      "type": "multi-config",
+      "ipam_type": "whereabouts",
+      "args": {
+        "p0": {
+          "range": "192.168.0.0/18"
+        },
+        "p1": {
+          "range": "192.168.64.0/18"
+        }
+      }
+    }
+  multiNICIPAM: false
+  plugin:
+    cniVersion: "0.3.0"
+    type: ipvlan
+    args: 
+      mode: l2


### PR DESCRIPTION
<!--
Please apply at most one applicable label from the below list to your PR.

- kind/feat
- kind/chore
- kind/fix

This will help us categorize your PR in the release note.

-->

- kind/feat
- 
#### What this PR does / why we need it:

<!--
Please explain your PR
-->

cherry-pick:
- https://github.com/foundation-model-stack/multi-nic-cni/commit/2755108e8d27ecdaeef801c46a30555457755031#diff-fe19ec3e0abcc014e6f066867b0d49b97d44612880eeca1ed72cb43d077325ea

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
-->

- https://github.com/foundation-model-stack/multi-nic-cni/issues/256
-

Based on
- https://github.com/foundation-model-stack/multi-nic-cni/pull/325

Need confirm whether the following change need from https://github.com/foundation-model-stack/multi-nic-cni/commit/f5e055081b27827b71599d150c8c6c918eea0d7a#diff-1db7710d390d807a0392e69569890b934ca93f62774731d52653cdc7f9eb012d

```diff
@@ -396,6 +396,10 @@ func loadConf(args *skel.CmdArgs) (*NetConf, string, error) {
	}
	selectResponse, err := selectNICs(n.DaemonIP, n.DaemonPort, podName, podNamespace, hostName, n.Name, nicSet, n.MasterNetAddrs)
	if err != nil {
+		if n.IPAM.Type == MultiConfigIPAMType {
+			// allow to have empty Masters
+			err = nil
+		}
		return n, deviceType, err
	}
	n.Masters = selectResponse.Masters
```