### PR TITLE
chore: update go version and fix kbuilder workflow

### DIFF
--- a/.github/workflows/build_push_kbuilder.yaml
+++ b/.github/workflows/build_push_kbuilder.yaml
@@ -8,7 +8,7 @@ on:
         required: true
 
 env:
-  IMAGE_VERSION: "1.2.9"
+  IMAGE_VERSION: ${{ github.event.inputs.version }}
 
 jobs:
   build-push:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.23.0'
+          go-version: '1.24.1'
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker


### PR DESCRIPTION
<!--
Please apply at most one applicable label from the below list to your PR.

- kind/feat
- kind/chore
- kind/fix

This will help us categorize your PR in the release note.

-->

kind/chore

#### What this PR does / why we need it:

<!--
Please explain your PR
-->

version input is not used to set IMAGE_VERSION.
This PR fixes that issue.

Additionally, this PR updates go version to 1.24.1.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
-->

- 
- 